### PR TITLE
feat(ips): add RequestOSPowerSavingStateChange, Get, Pull, & Enumerate

### DIFF
--- a/pkg/wsman/ips/messages.go
+++ b/pkg/wsman/ips/messages.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/hostbasedsetup"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ieee8021x"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/power"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
 )
 
@@ -22,6 +23,7 @@ type Messages struct {
 	AlarmClockOccurrence       alarmclock.Occurrence
 	IEEE8021xCredentialContext ieee8021x.CredentialContext
 	IEEE8021xSettings          ieee8021x.Settings
+	PowerManagementService     power.ManagementService
 }
 
 func NewMessages(client client.WSMan) Messages {
@@ -35,6 +37,7 @@ func NewMessages(client client.WSMan) Messages {
 	m.AlarmClockOccurrence = alarmclock.NewAlarmClockOccurrenceWithClient(wsmanMessageCreator, client)
 	m.IEEE8021xCredentialContext = ieee8021x.NewIEEE8021xCredentialContextWithClient(wsmanMessageCreator, client)
 	m.IEEE8021xSettings = ieee8021x.NewIEEE8021xSettingsWithClient(wsmanMessageCreator, client)
+	m.PowerManagementService = power.NewPowerManagementServiceWithClient(wsmanMessageCreator, client)
 
 	return m
 }

--- a/pkg/wsman/ips/messages_test.go
+++ b/pkg/wsman/ips/messages_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/hostbasedsetup"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ieee8021x"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/power"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
 )
 
@@ -42,5 +43,9 @@ func TestNewMessages(t *testing.T) {
 
 	if reflect.DeepEqual(m.IEEE8021xSettings, ieee8021x.Settings{}) {
 		t.Error("BootSettingData is not initialized")
+	}
+
+	if reflect.DeepEqual(m.PowerManagementService, power.ManagementService{}) {
+		t.Error("PowerManagementService is not initialized")
 	}
 }

--- a/pkg/wsman/ips/power/decoder.go
+++ b/pkg/wsman/ips/power/decoder.go
@@ -1,0 +1,143 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2025
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package power
+
+const (
+	IPSPowerManagementService       string = "IPS_PowerManagementService"
+	RequestOSPowerSavingStateChange string = "RequestOSPowerSavingStateChange"
+	ValueNotFound                   string = "Value not found in map"
+)
+
+// TODO: This list of contants needs to be scrubbed.
+const (
+	// Unknown.
+	Unknown OSPowerSavingState = 0 // Unknown OS Power Saving State
+
+	// Unsupported
+	Unsupported OSPowerSavingState = 1 // Unsupported
+
+	// Full Power.
+	FullPower OSPowerSavingState = 2 // Full Power
+
+	// OS power saving.
+	OSPowerSaving OSPowerSavingState = 3 // OS power saving
+)
+
+const (
+	EnabledStateUnknown EnabledState = iota
+	EnabledStateOther
+	EnabledStateEnabled
+	EnabledStateDisabled
+	EnabledStateShuttingDown
+	EnabledStateNotApplicable
+	EnabledStateEnabledButOffline
+	EnabledStateInTest
+	EnabledStateDeferred
+	EnabledStateQuiesce
+	EnabledStateStarting
+)
+
+// enabledStateMap is a map of the EnabledState enumeration.
+var enabledStateMap = map[EnabledState]string{
+	EnabledStateUnknown:           "Unknown",
+	EnabledStateOther:             "Other",
+	EnabledStateEnabled:           "Enabled",
+	EnabledStateDisabled:          "Disabled",
+	EnabledStateShuttingDown:      "ShuttingDown",
+	EnabledStateNotApplicable:     "NotApplicable",
+	EnabledStateEnabledButOffline: "EnabledButOffline",
+	EnabledStateInTest:            "InTest",
+	EnabledStateDeferred:          "Deferred",
+	EnabledStateQuiesce:           "Quiesce",
+	EnabledStateStarting:          "Starting",
+}
+
+// String returns a human-readable string representation of the EnabledState enumeration.
+func (e EnabledState) String() string {
+	if s, ok := enabledStateMap[e]; ok {
+		return s
+	}
+
+	return ValueNotFound
+}
+
+const (
+	RequestedStateUnknown       RequestedState = 0
+	RequestedStateEnabled       RequestedState = 2
+	RequestedStateDisabled      RequestedState = 3
+	RequestedStateShutDown      RequestedState = 4
+	RequestedStateNoChange      RequestedState = 5
+	RequestedStateOffline       RequestedState = 6
+	RequestedStateTest          RequestedState = 7
+	RequestedStateDeferred      RequestedState = 8
+	RequestedStateQuiesce       RequestedState = 9
+	RequestedStateReboot        RequestedState = 10
+	RequestedStateReset         RequestedState = 11
+	RequestedStateNotApplicable RequestedState = 12
+)
+
+// requestedStateMap is a map of the RequestedState enumeration.
+var requestedStateMap = map[RequestedState]string{
+	RequestedStateUnknown:       "Unknown",
+	RequestedStateEnabled:       "Enabled",
+	RequestedStateDisabled:      "Disabled",
+	RequestedStateShutDown:      "ShutDown",
+	RequestedStateNoChange:      "NoChange",
+	RequestedStateOffline:       "Offline",
+	RequestedStateTest:          "Test",
+	RequestedStateDeferred:      "Deferred",
+	RequestedStateQuiesce:       "Quiesce",
+	RequestedStateReboot:        "Reboot",
+	RequestedStateReset:         "Reset",
+	RequestedStateNotApplicable: "NotApplicable",
+}
+
+// String returns a human-readable string representation of the RequestedState enumeration.
+func (e RequestedState) String() string {
+	if s, ok := requestedStateMap[e]; ok {
+		return s
+	}
+
+	return ValueNotFound
+}
+
+const (
+	ReturnValueCompletedWithNoError              ReturnValue = 0
+	ReturnValueMethodNotSupported                ReturnValue = 1
+	ReturnValueUnknownError                      ReturnValue = 2
+	ReturnValueCannotCompleteWithinTimeoutPeriod ReturnValue = 3
+	ReturnValueFailed                            ReturnValue = 4
+	ReturnValueInvalidParameter                  ReturnValue = 5
+	ReturnValueInUse                             ReturnValue = 6
+	ReturnValueMethodParametersCheckedJobStarted ReturnValue = 4096
+	ReturnValueInvalidStateTransition            ReturnValue = 4097
+	ReturnValueUseOfTimeoutParameterNotSupported ReturnValue = 4098
+	ReturnValueBusy                              ReturnValue = 4099
+)
+
+// returnValueMap is a map of the ReturnValue enumeration.
+var returnValueMap = map[ReturnValue]string{
+	ReturnValueCompletedWithNoError:              "CompletedWithNoError",
+	ReturnValueMethodNotSupported:                "MethodNotSupported",
+	ReturnValueUnknownError:                      "UnknownError",
+	ReturnValueCannotCompleteWithinTimeoutPeriod: "CannotCompleteWithinTimeoutPeriod",
+	ReturnValueFailed:                            "Failed",
+	ReturnValueInvalidParameter:                  "InvalidParameter",
+	ReturnValueInUse:                             "InUse",
+	ReturnValueMethodParametersCheckedJobStarted: "MethodParametersCheckedJobStarted",
+	ReturnValueInvalidStateTransition:            "InvalidStateTransition",
+	ReturnValueUseOfTimeoutParameterNotSupported: "UseOfTimeoutParameterNotSupported",
+	ReturnValueBusy:                              "Busy",
+}
+
+// String returns a human-readable string representation of the ReturnValue enumeration.
+func (e ReturnValue) String() string {
+	if s, ok := returnValueMap[e]; ok {
+		return s
+	}
+
+	return ValueNotFound
+}

--- a/pkg/wsman/ips/power/decoder_test.go
+++ b/pkg/wsman/ips/power/decoder_test.go
@@ -1,0 +1,90 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2025
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package power
+
+import "testing"
+
+func TestEnabledState_String(t *testing.T) {
+	tests := []struct {
+		state    EnabledState
+		expected string
+	}{
+		{EnabledStateUnknown, "Unknown"},
+		{EnabledStateOther, "Other"},
+		{EnabledStateEnabled, "Enabled"},
+		{EnabledStateDisabled, "Disabled"},
+		{EnabledStateShuttingDown, "ShuttingDown"},
+		{EnabledStateNotApplicable, "NotApplicable"},
+		{EnabledStateEnabledButOffline, "EnabledButOffline"},
+		{EnabledStateInTest, "InTest"},
+		{EnabledStateDeferred, "Deferred"},
+		{EnabledStateQuiesce, "Quiesce"},
+		{EnabledStateStarting, "Starting"},
+		{EnabledState(999), "Value not found in map"},
+	}
+
+	for _, test := range tests {
+		result := test.state.String()
+		if result != test.expected {
+			t.Errorf("Expected %s, but got %s", test.expected, result)
+		}
+	}
+}
+
+func TestRequestedState_String(t *testing.T) {
+	tests := []struct {
+		state    RequestedState
+		expected string
+	}{
+		{RequestedStateUnknown, "Unknown"},
+		{RequestedStateEnabled, "Enabled"},
+		{RequestedStateDisabled, "Disabled"},
+		{RequestedStateShutDown, "ShutDown"},
+		{RequestedStateNoChange, "NoChange"},
+		{RequestedStateOffline, "Offline"},
+		{RequestedStateTest, "Test"},
+		{RequestedStateDeferred, "Deferred"},
+		{RequestedStateQuiesce, "Quiesce"},
+		{RequestedStateReboot, "Reboot"},
+		{RequestedStateReset, "Reset"},
+		{RequestedStateNotApplicable, "NotApplicable"},
+		{RequestedState(999), "Value not found in map"},
+	}
+
+	for _, test := range tests {
+		result := test.state.String()
+		if result != test.expected {
+			t.Errorf("Expected %s, but got %s", test.expected, result)
+		}
+	}
+}
+
+func TestReturnValue_String(t *testing.T) {
+	tests := []struct {
+		state    ReturnValue
+		expected string
+	}{
+		{ReturnValueCompletedWithNoError, "CompletedWithNoError"},
+		{ReturnValueMethodNotSupported, "MethodNotSupported"},
+		{ReturnValueUnknownError, "UnknownError"},
+		{ReturnValueCannotCompleteWithinTimeoutPeriod, "CannotCompleteWithinTimeoutPeriod"},
+		{ReturnValueFailed, "Failed"},
+		{ReturnValueInvalidParameter, "InvalidParameter"},
+		{ReturnValueInUse, "InUse"},
+		{ReturnValueMethodParametersCheckedJobStarted, "MethodParametersCheckedJobStarted"},
+		{ReturnValueInvalidStateTransition, "InvalidStateTransition"},
+		{ReturnValueUseOfTimeoutParameterNotSupported, "UseOfTimeoutParameterNotSupported"},
+		{ReturnValueBusy, "Busy"},
+		{ReturnValue(999), "Value not found in map"},
+	}
+
+	for _, test := range tests {
+		result := test.state.String()
+		if result != test.expected {
+			t.Errorf("Expected %s, but got %s", test.expected, result)
+		}
+	}
+}

--- a/pkg/wsman/ips/power/managementservice.go
+++ b/pkg/wsman/ips/power/managementservice.go
@@ -1,0 +1,114 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2025
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package power facilitates communication with Intel® AMT devices where a class derived from Service describes power management functionality, hosted on a System.
+//
+// Whether this service might be used to affect the power state of a particular element is defined by the CIM_ServiceAvailable ToElement association.
+package power
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/methods"
+)
+
+// NewPowerManagementService returns a new instance of the PowerManagementService struct.
+func NewPowerManagementServiceWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) ManagementService {
+	return ManagementService{
+		base: message.NewBaseWithClient(wsmanMessageCreator, IPSPowerManagementService, client),
+	}
+}
+
+// RequestOSPowerSavingStateChange defines the desired OS powersaving state of the managed element, and when the element should be put into that state.
+func (managementService ManagementService) RequestOSPowerSavingStateChange(osPowerSavingState OSPowerSavingState) (response Response, err error) {
+	header := managementService.base.WSManMessageCreator.CreateHeader(methods.GenerateAction(IPSPowerManagementService, RequestOSPowerSavingStateChange), IPSPowerManagementService, nil, "", "")
+
+	body := fmt.Sprintf(`<Body><h:RequestOSPowerSavingStateChange_INPUT xmlns:h="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService"><h:OSPowerSavingState>%d</h:OSPowerSavingState><h:ManagedElement><Address xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.xmlsoap.org/ws/2004/08/addressing</Address><ReferenceParameters xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing"><ResourceURI xmlns="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ComputerSystem</ResourceURI><SelectorSet xmlns="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"><Selector Name="CreationClassName">CIM_ComputerSystem</Selector><Selector Name="Name">ManagedSystem</Selector></SelectorSet></ReferenceParameters></h:ManagedElement></h:RequestOSPowerSavingStateChange_INPUT></Body>`, osPowerSavingState)
+	response = Response{
+		Message: &client.Message{
+			XMLInput: managementService.base.WSManMessageCreator.CreateXML(header, body),
+		},
+	}
+
+	// send the message to AMT
+	err = managementService.base.Execute(response.Message)
+	if err != nil {
+		return
+	}
+
+	// put the xml response into the go struct
+	err = xml.Unmarshal([]byte(response.XMLOutput), &response)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// Get retrieves the representation of the instance.
+func (managementService ManagementService) Get() (response Response, err error) {
+	response = Response{
+		Message: &client.Message{
+			XMLInput: managementService.base.Get(nil),
+		},
+	}
+
+	err = managementService.base.Execute(response.Message)
+	if err != nil {
+		return
+	}
+
+	err = xml.Unmarshal([]byte(response.XMLOutput), &response)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// // Enumerate returns an enumeration context which is used in a subsequent Pull call.
+func (managementService ManagementService) Enumerate() (response Response, err error) {
+	response = Response{
+		Message: &client.Message{
+			XMLInput: managementService.base.Enumerate(),
+		},
+	}
+
+	err = managementService.base.Execute(response.Message)
+	if err != nil {
+		return
+	}
+
+	err = xml.Unmarshal([]byte(response.XMLOutput), &response)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// Pull returns the instances of this class.  An enumeration context provided by the Enumerate call is used as input.
+func (managementService ManagementService) Pull(enumerationContext string) (response Response, err error) {
+	response = Response{
+		Message: &client.Message{
+			XMLInput: managementService.base.Pull(enumerationContext),
+		},
+	}
+
+	err = managementService.base.Execute(response.Message)
+	if err != nil {
+		return
+	}
+
+	err = xml.Unmarshal([]byte(response.XMLOutput), &response)
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/pkg/wsman/ips/power/managementservice_test.go
+++ b/pkg/wsman/ips/power/managementservice_test.go
@@ -1,0 +1,288 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2025
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package power
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/methods"
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+const (
+	RequestOSPowerSavingStateChangeBODY = "<h:RequestOSPowerSavingStateChange_INPUT xmlns:h=\"http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService\"><h:OSPowerSavingState>3</h:OSPowerSavingState><h:ManagedElement><Address xmlns=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\">http://schemas.xmlsoap.org/ws/2004/08/addressing</Address><ReferenceParameters xmlns=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\"><ResourceURI xmlns=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\">http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ComputerSystem</ResourceURI><SelectorSet xmlns=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\"><Selector Name=\"CreationClassName\">CIM_ComputerSystem</Selector><Selector Name=\"Name\">ManagedSystem</Selector></SelectorSet></ReferenceParameters></h:ManagedElement></h:RequestOSPowerSavingStateChange_INPUT>"
+)
+
+func TestJson(t *testing.T) {
+	response := Response{
+		Body: Body{
+			PullResponse: PullResponse{},
+		},
+	}
+	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"RequestOSPowerSavingStateChangeResponse\":{\"ReturnValue\":0},\"GetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"CreationClassName\":\"\",\"ElementName\":\"\",\"EnabledState\":0,\"Name\":\"\",\"RequestedState\":0,\"SystemCreationClassName\":\"\",\"SystemName\":\"\",\"OSPowerSavingState\":0},\"EnumerateResponse\":{\"EnumerationContext\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"PowerManagementServiceItems\":null}}"
+	result := response.JSON()
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestYaml(t *testing.T) {
+	response := Response{
+		Body: Body{
+			PullResponse: PullResponse{},
+		},
+	}
+	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\nrequestospowersavingstatechangeresponse:\n    returnvalue: 0\ngetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    creationclassname: \"\"\n    elementname: \"\"\n    enabledstate: 0\n    name: \"\"\n    requestedstate: 0\n    systemcreationclassname: \"\"\n    systemname: \"\"\n    ospowersavingstate: 0\nenumerateresponse:\n    enumerationcontext: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    powermanagementserviceitems: []\n"
+	result := response.YAML()
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestPositiveCIMPowerManagementService(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.IPSResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "ips/power/managementservice",
+	}
+	elementUnderTest := NewPowerManagementServiceWithClient(wsmanMessageCreator, &client)
+
+	t.Run("ips_PowerManagementService Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"Should issue a valid ips_PowerManagementService RequestOSPowerSavingStateChange call",
+				IPSPowerManagementService,
+				methods.GenerateAction(IPSPowerManagementService, RequestOSPowerSavingStateChange),
+				RequestOSPowerSavingStateChangeBODY,
+				func() (Response, error) {
+					client.CurrentMessage = "RequestOSPowerSavingStateChange"
+					osPowerSavingState := OSPowerSaving
+
+					return elementUnderTest.RequestOSPowerSavingStateChange(osPowerSavingState)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					RequestOSPowerSavingStateChangeResponse: PowerActionResponse{
+						ReturnValue: 0,
+					},
+				},
+			},
+			{
+				"Should issue a valid ips_PowerManagementService Get call",
+				IPSPowerManagementService,
+				wsmantesting.Get,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageGet
+
+					return elementUnderTest.Get()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					GetResponse: PowerManagementService{
+						XMLName:                 xml.Name{Space: "http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService", Local: "IPS_PowerManagementService"},
+						CreationClassName:       "IPS_PowerManagementService",
+						ElementName:             "Intel(r) AMT Power Management Service",
+						EnabledState:            5,
+						Name:                    "Intel(r) AMT Power Management Service",
+						RequestedState:          12,
+						SystemCreationClassName: "CIM_ComputerSystem",
+						SystemName:              "Intel(r) AMT",
+						OSPowerSavingState:      2,
+					},
+				},
+			},
+			{
+				"Should issue a valid ips_PowerManagementService Enumerate call",
+				IPSPowerManagementService,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{
+						EnumerationContext: "DB020000-0000-0000-0000-000000000000",
+					},
+				},
+			},
+			{
+				"Should issue a valid ips_PowerManagementService Pull call",
+				IPSPowerManagementService,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: "http://schemas.xmlsoap.org/ws/2004/09/enumeration", Local: "PullResponse"},
+						PowerManagementServiceItems: []PowerManagementService{
+							{
+								XMLName:                 xml.Name{Space: "http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService", Local: "IPS_PowerManagementService"},
+								CreationClassName:       "IPS_PowerManagementService",
+								ElementName:             "Intel(r) AMT Power Management Service",
+								EnabledState:            5,
+								Name:                    "Intel(r) AMT Power Management Service",
+								RequestedState:          12,
+								SystemCreationClassName: "CIM_ComputerSystem",
+								SystemName:              "Intel(r) AMT",
+								OSPowerSavingState:      2,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, "", test.body)
+				messageID++
+				response, err := test.responseFunc()
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}
+
+func TestNegativeCIMPowerManagementService(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.IPSResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "ips/power/managementservice",
+	}
+	elementUnderTest := NewPowerManagementServiceWithClient(wsmanMessageCreator, &client)
+
+	t.Run("ips_PowerManagementService Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"Should issue a valid ips_PowerManagementService RequestOSPowerSavingStateChange call",
+				IPSPowerManagementService,
+				methods.GenerateAction(IPSPowerManagementService, RequestOSPowerSavingStateChange),
+				RequestOSPowerSavingStateChangeBODY,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+					osPowerSavingState := OSPowerSaving
+
+					return elementUnderTest.RequestOSPowerSavingStateChange(osPowerSavingState)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					RequestOSPowerSavingStateChangeResponse: PowerActionResponse{
+						ReturnValue: 0,
+					},
+				},
+			},
+			{
+				"Should issue a valid ips_PowerManagementService Get call",
+				IPSPowerManagementService,
+				wsmantesting.Get,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Get()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					GetResponse: PowerManagementService{
+						XMLName:                 xml.Name{Space: "http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService", Local: "IPS_PowerManagementService"},
+						CreationClassName:       "IPS_PowerManagementService",
+						ElementName:             "Intel(r) AMT Power Management Service",
+						EnabledState:            5,
+						Name:                    "Intel(r) AMT Power Management Service",
+						RequestedState:          12,
+						SystemCreationClassName: "CIM_ComputerSystem",
+						SystemName:              "Intel(r) AMT",
+					},
+				},
+			},
+			{
+				"Should issue a valid ips_PowerManagementService Enumerate call",
+				IPSPowerManagementService,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{
+						EnumerationContext: "DB020000-0000-0000-0000-000000000000",
+					},
+				},
+			},
+			{
+				"Should issue a valid ips_PowerManagementService Pull call",
+				IPSPowerManagementService,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: "http://schemas.xmlsoap.org/ws/2004/09/enumeration", Local: "PullResponse"},
+						PowerManagementServiceItems: []PowerManagementService{
+							{
+								XMLName:                 xml.Name{Space: "http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService", Local: "IPS_PowerManagementService"},
+								CreationClassName:       "IPS_PowerManagementService",
+								ElementName:             "Intel(r) AMT Power Management Service",
+								EnabledState:            5,
+								Name:                    "Intel(r) AMT Power Management Service",
+								RequestedState:          12,
+								SystemCreationClassName: "CIM_ComputerSystem",
+								SystemName:              "Intel(r) AMT",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, "", test.body)
+				messageID++
+				response, err := test.responseFunc()
+				assert.Error(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.NotEqual(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}

--- a/pkg/wsman/ips/power/marshal.go
+++ b/pkg/wsman/ips/power/marshal.go
@@ -1,0 +1,32 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2025
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package power
+
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+// JSON marshals the type into JSON format.
+func (r *Response) JSON() string {
+	jsonOutput, err := json.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(jsonOutput)
+}
+
+// YAML marshals the type into YAML format.
+func (r *Response) YAML() string {
+	yamlOutput, err := yaml.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(yamlOutput)
+}

--- a/pkg/wsman/ips/power/types.go
+++ b/pkg/wsman/ips/power/types.go
@@ -1,0 +1,65 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2025
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package power
+
+import (
+	"encoding/xml"
+
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+)
+
+type ManagementService struct {
+	base message.Base
+}
+
+type OSPowerSavingState int
+
+// Response Types.
+type (
+	Response struct {
+		*client.Message
+		XMLName xml.Name       `xml:"Envelope"`
+		Header  message.Header `xml:"Header"`
+		Body    Body           `xml:"Body"`
+	}
+	Body struct {
+		XMLName                                 xml.Name            `xml:"Body"`
+		RequestOSPowerSavingStateChangeResponse PowerActionResponse `xml:"RequestOSPowerSavingStateChange_OUTPUT"`
+		GetResponse                             PowerManagementService
+		EnumerateResponse                       common.EnumerateResponse
+		PullResponse                            PullResponse
+	}
+
+	PullResponse struct {
+		XMLName                     xml.Name                 `xml:"PullResponse"`
+		PowerManagementServiceItems []PowerManagementService `xml:"Items>IPS_PowerManagementService"`
+	}
+
+	PowerManagementService struct {
+		XMLName                 xml.Name           `xml:"IPS_PowerManagementService"`
+		CreationClassName       string             `xml:"CreationClassName,omitempty"`       // CreationClassName indicates the name of the class or the subclass that is used in the creation of an instance.
+		ElementName             string             `xml:"ElementName,omitempty"`             // A user-friendly name for the object.
+		EnabledState            EnabledState       `xml:"EnabledState,omitempty"`            // EnabledState is an integer enumeration that indicates the enabled and disabled states of an element.
+		Name                    string             `xml:"Name,omitempty"`                    // The Name property uniquely identifies the Service and provides an indication of the functionality that is managed.
+		RequestedState          RequestedState     `xml:"RequestedState,omitempty"`          // RequestedState is an integer enumeration that indicates the last requested or desired state for the element, irrespective of the mechanism through which it was requested.
+		SystemCreationClassName string             `xml:"SystemCreationClassName,omitempty"` // The CreationClassName of the scoping System.
+		SystemName              string             `xml:"SystemName,omitempty"`              // The Name of the scoping System.
+		OSPowerSavingState      OSPowerSavingState `xml:"OSPowerSavingState,omitempty"`      // OSPowerSavingState is an integer enumeration that indicates the current power saving state of the operating system.
+	}
+
+	PowerActionResponse struct {
+		ReturnValue ReturnValue `xml:"ReturnValue"`
+	}
+
+	// EnabledState is an integer enumeration that indicates the enabled and disabled states of an element.
+	EnabledState int
+	// RequestedState is an integer enumeration that indicates the last requested or desired state for the element, irrespective of the mechanism through which it was requested.
+	RequestedState int
+	// ReturnValue is an integer enumeration that indicates the success or failure of an operation.
+	ReturnValue int
+)

--- a/pkg/wsman/wsmantesting/responses/ips/power/managementservice/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/power/managementservice/enumerate.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>0</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000E8D</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:EnumerateResponse>
+            <g:EnumerationContext>DB020000-0000-0000-0000-000000000000</g:EnumerationContext>
+        </g:EnumerateResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/power/managementservice/get.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/power/managementservice/get.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService"
+    xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/common"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>0</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000E8C</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:IPS_PowerManagementService>
+            <g:CreationClassName>IPS_PowerManagementService</g:CreationClassName>
+            <g:ElementName>Intel(r) AMT Power Management Service</g:ElementName>
+            <g:EnabledState>5</g:EnabledState>
+            <g:Name>Intel(r) AMT Power Management Service</g:Name>
+            <g:RequestedState>12</g:RequestedState>
+            <g:SystemCreationClassName>CIM_ComputerSystem</g:SystemCreationClassName>
+            <g:SystemName>Intel(r) AMT</g:SystemName>
+            <g:OSPowerSavingState>2</g:OSPowerSavingState>
+        </g:IPS_PowerManagementService>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/power/managementservice/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/power/managementservice/pull.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:h="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService"
+    xmlns:i="http://schemas.dmtf.org/wbem/wscim/1/common"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>1</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000E8F</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:PullResponse>
+            <g:Items>
+                <h:IPS_PowerManagementService>
+                    <h:CreationClassName>IPS_PowerManagementService</h:CreationClassName>
+                    <h:ElementName>Intel(r) AMT Power Management Service</h:ElementName>
+                    <h:EnabledState>5</h:EnabledState>
+                    <h:Name>Intel(r) AMT Power Management Service</h:Name>
+                    <h:RequestedState>12</h:RequestedState>
+                    <h:SystemCreationClassName>CIM_ComputerSystem</h:SystemCreationClassName>
+                    <h:SystemName>Intel(r) AMT</h:SystemName>
+                    <h:OSPowerSavingState>2</h:OSPowerSavingState>
+                </h:IPS_PowerManagementService>
+            </g:Items>
+            <g:EndOfSequence></g:EndOfSequence>
+        </g:PullResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/power/managementservice/requestospowersavingstatechange.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/power/managementservice/requestospowersavingstatechange.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>0</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService/RequestOSPowerSavingStateChangeResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-0000000003B8</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_PowerManagementService</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:RequestOSPowerSavingStateChange_OUTPUT>
+            <g:ReturnValue>0</g:ReturnValue>
+        </g:RequestOSPowerSavingStateChange_OUTPUT>
+    </a:Body>
+</a:Envelope>


### PR DESCRIPTION
It implements the required functions for the IPS Power Management Service.

"*Currently /api/v1/amt/power/action/{guid} "action": 2, will not wake a system in Modern/Connected Standby. It will return 200, but the system will remain in Modern/Connected Standby. To wake a system in that state, you need to call PowerManagementService.RequestOSPowerSavingStateChange with "Full Power" as "OSPowerSavingState"...*" [Link](https://github.com/orgs/device-management-toolkit/projects/10/views/3?pane=issue&itemId=57248651&issue=device-management-toolkit%7Cmps%7C1373)

It incorporates Get, Pull. Enumerate and RequestOSPowerSavingStateChange. 

So, we have the required messages to verify and implement the changes you asked for.
Modifications in the wsman-messages project have been incorporated through [PR#967](https://github.com/device-management-toolkit/wsman-messages/pull/967)

Unit Tests have been added and executed.