### PR TITLE
feat: add RPE parameter types, sizes, and validation maps

### DIFF
--- a/pkg/wsman/amt/boot/types.go
+++ b/pkg/wsman/amt/boot/types.go
@@ -135,6 +135,7 @@ type BootSettingDataRequest struct {
 	OptionsCleared           bool              `xml:"h:OptionsCleared"`           // Indicates whether the boot options have been cleared by BIOS or not. This property is read only.
 	OwningEntity             string            `xml:"h:OwningEntity"`             // OwningEntity identifies the vendor or organization that defines the contained boot settings.
 	PlatformErase            bool              `xml:"h:PlatformErase"`            // When set to True, sets the boot option to trigger Secure Remote Platform Erase in the next boot.  Note: This command needs to execute over TLS.
+	RPEEnabled               bool              `xml:"h:RPEEnabled"`               // Indicates whether Secure Remote Platform Erase is enabled by the BIOS (read-only).
 	RSEPassword              string            `xml:"h:RSEPassword"`              // SSD password for Remote Secure Erase operation. This is a write-only field, an empty string is returned when instance is read. When writing, an empty string or lack of field will be ignored. The password length is limited to 32 ASCII characters. Note: Customers are recommended to use Secure Remote Platform Erase which is newer and more advanced than Remote Secure Erase.
 	ReflashBIOS              bool              `xml:"h:ReflashBIOS"`              // Required. When True, the Intel® AMT firmware reflashes the BIOS on the next boot cycle. This property can be set to true only when a boot source isn't set (using CIM_BootConfigSetting.ChangeBootOrder method).
 	SecureBootControlEnabled bool              `xml:"h:SecureBootControlEnabled"` // Determines whether Intel AMT is privileged by BIOS to disable secure boot for an AMT triggered boot option. If not, BIOSSecureBoot must be set to TRUE. This property is read only.
@@ -296,6 +297,58 @@ var ParameterDetails = map[ParameterType]struct {
 	OCR_HTTPS_PASSWORD: {
 		Mandatory: false,
 		Comment:   "Optional for HTTPS boot",
+	},
+}
+
+// RPE Parameter Types for Remote Platform Erase.
+const (
+	RPE_DEVICE_BITMASK      ParameterType = 1
+	RPE_PSID                ParameterType = 10
+	RPE_SSD_MASTER_PASSWORD ParameterType = 20
+	RPE_OEM_PARAMETER       ParameterType = 30
+)
+
+// RPE parameter max sizes (in bytes).
+var RPEMaxSizes = map[ParameterType]int{
+	RPE_DEVICE_BITMASK:      4,
+	RPE_PSID:                64,
+	RPE_SSD_MASTER_PASSWORD: 64,
+	RPE_OEM_PARAMETER:       500,
+}
+
+// RPE parameter names for friendly error messages.
+var RPEParameterNames = map[ParameterType]string{
+	RPE_DEVICE_BITMASK:      "Bit mask of devices to clear",
+	RPE_PSID:                "PSID for pyrite drive revert/clear",
+	RPE_SSD_MASTER_PASSWORD: "SSD master password",
+	RPE_OEM_PARAMETER:       "OEM defined additional parameter",
+}
+
+// RPE parameter details for validation rules.
+var RPEParameterDetails = map[ParameterType]struct {
+	Mandatory         bool
+	UsedInUnconfigure bool
+	Comment           string
+}{
+	RPE_DEVICE_BITMASK: {
+		Mandatory:         true,
+		UsedInUnconfigure: true,
+		Comment:           "Bit mask of devices that should be cleared (use the bit mask specified in AMT_BootCapabilities.PlatformErase)",
+	},
+	RPE_PSID: {
+		Mandatory:         false,
+		UsedInUnconfigure: false,
+		Comment:           "PSID used to revert/clear pyrite drive",
+	},
+	RPE_SSD_MASTER_PASSWORD: {
+		Mandatory:         false,
+		UsedInUnconfigure: false,
+		Comment:           "Password used to clear SSD",
+	},
+	RPE_OEM_PARAMETER: {
+		Mandatory:         false,
+		UsedInUnconfigure: false,
+		Comment:           "OEM defined parameters",
 	},
 }
 

--- a/pkg/wsman/amt/boot/types_test.go
+++ b/pkg/wsman/amt/boot/types_test.go
@@ -1,0 +1,125 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2023
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package boot
+
+import (
+	"testing"
+)
+
+func TestRPEParameterTypeValues(t *testing.T) {
+	tests := []struct {
+		name      string
+		paramType ParameterType
+		expected  ParameterType
+	}{
+		{name: "RPE_DEVICE_BITMASK", paramType: RPE_DEVICE_BITMASK, expected: 1},
+		{name: "RPE_PSID", paramType: RPE_PSID, expected: 10},
+		{name: "RPE_SSD_MASTER_PASSWORD", paramType: RPE_SSD_MASTER_PASSWORD, expected: 20},
+		{name: "RPE_OEM_PARAMETER", paramType: RPE_OEM_PARAMETER, expected: 30},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.paramType != tt.expected {
+				t.Errorf("%s = %v, want %v", tt.name, tt.paramType, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRPEMaxSizes(t *testing.T) {
+	allRPETypes := []ParameterType{
+		RPE_DEVICE_BITMASK,
+		RPE_PSID,
+		RPE_SSD_MASTER_PASSWORD,
+		RPE_OEM_PARAMETER,
+	}
+
+	for _, paramType := range allRPETypes {
+		if _, ok := RPEMaxSizes[paramType]; !ok {
+			t.Errorf("RPEMaxSizes missing entry for ParameterType %v", paramType)
+		}
+	}
+
+	expectedSizes := map[ParameterType]int{
+		RPE_DEVICE_BITMASK:      4,
+		RPE_PSID:                64,
+		RPE_SSD_MASTER_PASSWORD: 64,
+		RPE_OEM_PARAMETER:       500,
+	}
+
+	for paramType, size := range expectedSizes {
+		if RPEMaxSizes[paramType] != size {
+			t.Errorf("RPEMaxSizes[%v] = %v, want %v", paramType, RPEMaxSizes[paramType], size)
+		}
+	}
+}
+
+func TestRPEParameterNames(t *testing.T) {
+	allRPETypes := []ParameterType{
+		RPE_DEVICE_BITMASK,
+		RPE_PSID,
+		RPE_SSD_MASTER_PASSWORD,
+		RPE_OEM_PARAMETER,
+	}
+
+	for _, paramType := range allRPETypes {
+		name, ok := RPEParameterNames[paramType]
+		if !ok {
+			t.Errorf("RPEParameterNames missing entry for ParameterType %v", paramType)
+
+			continue
+		}
+
+		if name == "" {
+			t.Errorf("RPEParameterNames[%v] is empty", paramType)
+		}
+	}
+}
+
+func TestRPEParameterDetails(t *testing.T) {
+	allRPETypes := []ParameterType{
+		RPE_DEVICE_BITMASK,
+		RPE_PSID,
+		RPE_SSD_MASTER_PASSWORD,
+		RPE_OEM_PARAMETER,
+	}
+
+	for _, paramType := range allRPETypes {
+		detail, ok := RPEParameterDetails[paramType]
+		if !ok {
+			t.Errorf("RPEParameterDetails missing entry for ParameterType %v", paramType)
+
+			continue
+		}
+
+		if detail.Comment == "" {
+			t.Errorf("RPEParameterDetails[%v].Comment is empty", paramType)
+		}
+	}
+
+	// RPE_DEVICE_BITMASK is the only mandatory parameter
+	if !RPEParameterDetails[RPE_DEVICE_BITMASK].Mandatory {
+		t.Errorf("RPEParameterDetails[RPE_DEVICE_BITMASK].Mandatory should be true")
+	}
+
+	for _, paramType := range []ParameterType{RPE_PSID, RPE_SSD_MASTER_PASSWORD, RPE_OEM_PARAMETER} {
+		if RPEParameterDetails[paramType].Mandatory {
+			t.Errorf("RPEParameterDetails[%v].Mandatory should be false", paramType)
+		}
+	}
+
+	// RPE_DEVICE_BITMASK is the only parameter used in unconfigure
+	if !RPEParameterDetails[RPE_DEVICE_BITMASK].UsedInUnconfigure {
+		t.Errorf("RPEParameterDetails[RPE_DEVICE_BITMASK].UsedInUnconfigure should be true")
+	}
+
+	for _, paramType := range []ParameterType{RPE_PSID, RPE_SSD_MASTER_PASSWORD, RPE_OEM_PARAMETER} {
+		if RPEParameterDetails[paramType].UsedInUnconfigure {
+			t.Errorf("RPEParameterDetails[%v].UsedInUnconfigure should be false", paramType)
+		}
+	}
+}

--- a/pkg/wsman/amt/boot/validator.go
+++ b/pkg/wsman/amt/boot/validator.go
@@ -224,6 +224,18 @@ func NewStringParameter(paramType ParameterType, value string) (TLVParameter, er
 	}, nil
 }
 
+// NewUint32Parameter creates a new parameter with a uint32 value (little-endian).
+func NewUint32Parameter(paramType ParameterType, value uint32) TLVParameter {
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, value)
+
+	return TLVParameter{
+		Type:   paramType,
+		Length: 4,
+		Value:  buf,
+	}
+}
+
 // NewBoolParameter creates a new parameter with a boolean value.
 func NewBoolParameter(paramType ParameterType, value bool) TLVParameter {
 	var boolValue byte = 0

--- a/pkg/wsman/amt/boot/validator_test.go
+++ b/pkg/wsman/amt/boot/validator_test.go
@@ -435,6 +435,60 @@ func TestNewBoolParameter(t *testing.T) {
 	}
 }
 
+func TestNewUint32Parameter(t *testing.T) {
+	tests := []struct {
+		name      string
+		paramType ParameterType
+		value     uint32
+	}{
+		{
+			name:      "Zero value",
+			paramType: RPE_DEVICE_BITMASK,
+			value:     0,
+		},
+		{
+			name:      "Device bitmask value",
+			paramType: RPE_DEVICE_BITMASK,
+			value:     0x00000003,
+		},
+		{
+			name:      "Max uint32 value",
+			paramType: RPE_DEVICE_BITMASK,
+			value:     0xFFFFFFFF,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			param := NewUint32Parameter(tt.paramType, tt.value)
+
+			if param.Type != tt.paramType {
+				t.Errorf("NewUint32Parameter() type = %v, want %v", param.Type, tt.paramType)
+			}
+
+			if param.Length != 4 {
+				t.Errorf("NewUint32Parameter() length = %v, want 4", param.Length)
+			}
+
+			if len(param.Value) != 4 {
+				t.Fatalf("NewUint32Parameter() value length = %v, want 4", len(param.Value))
+			}
+
+			// Verify little-endian encoding
+			expected := []byte{
+				byte(tt.value),
+				byte(tt.value >> 8),
+				byte(tt.value >> 16),
+				byte(tt.value >> 24),
+			}
+
+			if !bytes.Equal(param.Value, expected) {
+				t.Errorf("NewUint32Parameter() value = %v, want %v", param.Value, expected)
+			}
+		})
+	}
+}
+
 func TestValidateParameters(t *testing.T) {
 	// Valid parameters with network device path
 	validParams := []TLVParameter{


### PR DESCRIPTION
## Add RPE parameter types, sizes, and validation maps

Adds support for Intel Remote Platform Erase (RPE) parameter definitions in `pkg/wsman/amt/boot/types.go`.

### Changes

**New constants** (`ParameterType`):

| Constant | ID | Description |
|---|---|---|
| `RPE_DEVICE_BITMASK` | 1 | Bit mask of devices to clear |
| `RPE_PSID` | 10 | PSID for pyrite drive revert/clear |
| `RPE_SSD_MASTER_PASSWORD` | 20 | Password used to clear SSD |
| `RPE_OEM_PARAMETER` | 30 | OEM defined additional parameter |

**New maps**:

- `RPEMaxSizes` — maximum allowed byte size per parameter type (4, 64, 64, 500 bytes)
- `RPEParameterNames` — human-readable names for error messaging
- `RPEParameterDetails` — validation metadata including `Mandatory` and `UsedInUnconfigure` flags per the Intel spec

### References

Based on the Intel AMT Remote Platform Erase parameter specification table.