### PR TITLE
feat: add missing wsman fetcher class function for IPS class

### DIFF
--- a/pkg/wsman/ips/hostbootreason/decoder.go
+++ b/pkg/wsman/ips/hostbootreason/decoder.go
@@ -1,0 +1,10 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package hostbootreason
+
+const (
+	IPSHostBootReason string = "IPS_HostBootReason"
+)

--- a/pkg/wsman/ips/hostbootreason/marshal.go
+++ b/pkg/wsman/ips/hostbootreason/marshal.go
@@ -1,0 +1,32 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package hostbootreason
+
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+// JSON marshals the type into JSON format.
+func (r *Response) JSON() string {
+	jsonOutput, err := json.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(jsonOutput)
+}
+
+// YAML marshals the type into YAML format.
+func (r *Response) YAML() string {
+	yamlOutput, err := yaml.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(yamlOutput)
+}

--- a/pkg/wsman/ips/hostbootreason/reason.go
+++ b/pkg/wsman/ips/hostbootreason/reason.go
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package hostbootreason facilitates communication with Intel(R) AMT devices for IPS_HostBootReason data.
+package hostbootreason
+
+import (
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/base"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+)
+
+type Service struct {
+	base.WSManService[Response]
+}
+
+// NewHostBootReasonWithClient creates a new IPS_HostBootReason service.
+func NewHostBootReasonWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) Service {
+	return Service{
+		base.NewService[Response](wsmanMessageCreator, IPSHostBootReason, client),
+	}
+}

--- a/pkg/wsman/ips/hostbootreason/reason_test.go
+++ b/pkg/wsman/ips/hostbootreason/reason_test.go
@@ -1,0 +1,141 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package hostbootreason
+
+import (
+	"encoding/xml"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+func TestJson(t *testing.T) {
+	response := Response{
+		Body: Body{
+			PullResponse: PullResponse{},
+		},
+	}
+	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"GetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"ElementName\":\"\",\"InstanceID\":\"\",\"PreviousSxState\":0,\"Reason\":0,\"ReasonDetails\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"HostBootReasonItems\":null},\"EnumerateResponse\":{\"EnumerationContext\":\"\"}}"
+	result := response.JSON()
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestYaml(t *testing.T) {
+	response := Response{
+		Body: Body{
+			PullResponse: PullResponse{},
+		},
+	}
+	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\ngetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    elementname: \"\"\n    instanceid: \"\"\n    previoussxstate: 0\n    reason: 0\n    reasondetails: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    hostbootreasonitems: []\nenumerateresponse:\n    enumerationcontext: \"\"\n"
+	result := response.YAML()
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestPositiveIPS_HostBootReason(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.IPSResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "ips/hostbootreason",
+	}
+	elementUnderTest := NewHostBootReasonWithClient(wsmanMessageCreator, &client)
+
+	t.Run("ips_HostBootReason Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			extraHeader      string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"should create a valid IPS_HostBootReason Get wsman message",
+				IPSHostBootReason,
+				wsmantesting.Get,
+				"",
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageGet
+
+					return elementUnderTest.Get()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					GetResponse: HostBootReasonResponse{
+						XMLName:         xml.Name{Space: fmt.Sprintf("%s%s", message.IPSSchema, IPSHostBootReason), Local: IPSHostBootReason},
+						ElementName:     "Intel(r) AMT:Host Boot Reason",
+						InstanceID:      "Intel(r) AMT:Host Boot Reason",
+						PreviousSxState: 0,
+						Reason:          1,
+						ReasonDetails:   "",
+					},
+				},
+			},
+			{
+				"should create a valid IPS_HostBootReason Enumerate wsman message",
+				IPSHostBootReason,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName:           xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{EnumerationContext: "97000000-0000-0000-0000-000000000000"},
+				},
+			},
+			{
+				"should create a valid IPS_HostBootReason Pull wsman message",
+				IPSHostBootReason,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: message.XMLPullResponseSpace, Local: "PullResponse"},
+						HostBootReasonItems: []HostBootReasonResponse{
+							{
+								XMLName:         xml.Name{Space: fmt.Sprintf("%s%s", message.IPSSchema, IPSHostBootReason), Local: IPSHostBootReason},
+								ElementName:     "Intel(r) AMT:Host Boot Reason",
+								InstanceID:      "Intel(r) AMT:Host Boot Reason",
+								PreviousSxState: 0,
+								Reason:          1,
+								ReasonDetails:   "",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, test.extraHeader, test.body)
+				messageID++
+				response, err := test.responseFunc()
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}

--- a/pkg/wsman/ips/hostbootreason/types.go
+++ b/pkg/wsman/ips/hostbootreason/types.go
@@ -1,0 +1,45 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package hostbootreason
+
+import (
+	"encoding/xml"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+)
+
+// OUTPUT.
+type (
+	Response struct {
+		*client.Message
+		XMLName xml.Name       `xml:"Envelope"`
+		Header  message.Header `xml:"Header"`
+		Body    Body           `xml:"Body"`
+	}
+
+	Body struct {
+		XMLName           xml.Name               `xml:"Body"`
+		GetResponse       HostBootReasonResponse `xml:"IPS_HostBootReason"`
+		PullResponse      PullResponse
+		EnumerateResponse common.EnumerateResponse
+	}
+
+	HostBootReasonResponse struct {
+		XMLName         xml.Name `xml:"IPS_HostBootReason"`
+		ElementName     string   `xml:"ElementName,omitempty"`
+		InstanceID      string   `xml:"InstanceID,omitempty"`
+		PreviousSxState int      `xml:"PreviousSxState,omitempty"`
+		Reason          int      `xml:"Reason,omitempty"`
+		ReasonDetails   string   `xml:"ReasonDetails,omitempty"`
+	}
+
+	PullResponse struct {
+		XMLName             xml.Name                 `xml:"PullResponse"`
+		HostBootReasonItems []HostBootReasonResponse `xml:"Items>IPS_HostBootReason"`
+	}
+)

--- a/pkg/wsman/ips/hostipsettings/decoder.go
+++ b/pkg/wsman/ips/hostipsettings/decoder.go
@@ -1,0 +1,10 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package hostipsettings
+
+const (
+	IPSHostIPSettings string = "IPS_HostIPSettings"
+)

--- a/pkg/wsman/ips/hostipsettings/marshal.go
+++ b/pkg/wsman/ips/hostipsettings/marshal.go
@@ -1,0 +1,32 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package hostipsettings
+
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+// JSON marshals the type into JSON format.
+func (r *Response) JSON() string {
+	jsonOutput, err := json.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(jsonOutput)
+}
+
+// YAML marshals the type into YAML format.
+func (r *Response) YAML() string {
+	yamlOutput, err := yaml.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(yamlOutput)
+}

--- a/pkg/wsman/ips/hostipsettings/settings.go
+++ b/pkg/wsman/ips/hostipsettings/settings.go
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package hostipsettings facilitates communication with Intel(R) AMT devices for IPS_HostIPSettings data.
+package hostipsettings
+
+import (
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/base"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+)
+
+type Settings struct {
+	base.WSManService[Response]
+}
+
+// NewHostIPSettingsWithClient creates a new IPS_HostIPSettings service.
+func NewHostIPSettingsWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) Settings {
+	return Settings{
+		base.NewService[Response](wsmanMessageCreator, IPSHostIPSettings, client),
+	}
+}

--- a/pkg/wsman/ips/hostipsettings/settings_test.go
+++ b/pkg/wsman/ips/hostipsettings/settings_test.go
@@ -1,0 +1,133 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package hostipsettings
+
+import (
+	"encoding/xml"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+func TestJson(t *testing.T) {
+	response := Response{
+		Body: Body{
+			PullResponse: PullResponse{},
+		},
+	}
+	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"GetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"DHCPEnabled\":false,\"ElementName\":\"\",\"InstanceID\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"HostIPSettingsItems\":null},\"EnumerateResponse\":{\"EnumerationContext\":\"\"}}"
+	result := response.JSON()
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestYaml(t *testing.T) {
+	response := Response{
+		Body: Body{
+			PullResponse: PullResponse{},
+		},
+	}
+	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\ngetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    dhcpenabled: false\n    elementname: \"\"\n    instanceid: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    hostipsettingsitems: []\nenumerateresponse:\n    enumerationcontext: \"\"\n"
+	result := response.YAML()
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestPositiveIPS_HostIPSettings(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.IPSResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{PackageUnderTest: "ips/hostipsettings"}
+	elementUnderTest := NewHostIPSettingsWithClient(wsmanMessageCreator, &client)
+
+	t.Run("ips_HostIPSettings Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			extraHeader      string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"should create a valid IPS_HostIPSettings Get wsman message",
+				IPSHostIPSettings,
+				wsmantesting.Get,
+				"",
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageGet
+
+					return elementUnderTest.Get()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					GetResponse: HostIPSettings{
+						XMLName:     xml.Name{Space: fmt.Sprintf("%s%s", message.IPSSchema, IPSHostIPSettings), Local: IPSHostIPSettings},
+						DHCPEnabled: false,
+						ElementName: "Intel(r) AMT: Host IP Settings",
+						InstanceID:  "Intel(r) AMT: Host IP Settings",
+					},
+				},
+			},
+			{
+				"should create a valid IPS_HostIPSettings Enumerate wsman message",
+				IPSHostIPSettings,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName:           xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{EnumerationContext: "9A000000-0000-0000-0000-000000000000"},
+				},
+			},
+			{
+				"should create a valid IPS_HostIPSettings Pull wsman message",
+				IPSHostIPSettings,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: message.XMLPullResponseSpace, Local: "PullResponse"},
+						HostIPSettingsItems: []HostIPSettings{{
+							XMLName:     xml.Name{Space: fmt.Sprintf("%s%s", message.IPSSchema, IPSHostIPSettings), Local: IPSHostIPSettings},
+							DHCPEnabled: false,
+							ElementName: "Intel(r) AMT: Host IP Settings",
+							InstanceID:  "Intel(r) AMT: Host IP Settings",
+						}},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, test.extraHeader, test.body)
+				messageID++
+				response, err := test.responseFunc()
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}

--- a/pkg/wsman/ips/hostipsettings/types.go
+++ b/pkg/wsman/ips/hostipsettings/types.go
@@ -1,0 +1,42 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package hostipsettings
+
+import (
+	"encoding/xml"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+)
+
+type (
+	Response struct {
+		*client.Message
+		XMLName xml.Name       `xml:"Envelope"`
+		Header  message.Header `xml:"Header"`
+		Body    Body           `xml:"Body"`
+	}
+
+	Body struct {
+		XMLName           xml.Name       `xml:"Body"`
+		GetResponse       HostIPSettings `xml:"IPS_HostIPSettings"`
+		PullResponse      PullResponse
+		EnumerateResponse common.EnumerateResponse
+	}
+
+	HostIPSettings struct {
+		XMLName     xml.Name `xml:"IPS_HostIPSettings"`
+		DHCPEnabled bool     `xml:"DHCPEnabled"`
+		ElementName string   `xml:"ElementName,omitempty"`
+		InstanceID  string   `xml:"InstanceID,omitempty"`
+	}
+
+	PullResponse struct {
+		XMLName             xml.Name         `xml:"PullResponse"`
+		HostIPSettingsItems []HostIPSettings `xml:"Items>IPS_HostIPSettings"`
+	}
+)

--- a/pkg/wsman/ips/ipv6portsettings/decoder.go
+++ b/pkg/wsman/ips/ipv6portsettings/decoder.go
@@ -1,0 +1,10 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package ipv6portsettings
+
+const (
+	IPSIPv6PortSettings string = "IPS_IPv6PortSettings"
+)

--- a/pkg/wsman/ips/ipv6portsettings/marshal.go
+++ b/pkg/wsman/ips/ipv6portsettings/marshal.go
@@ -1,0 +1,32 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package ipv6portsettings
+
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+// JSON marshals the type into JSON format.
+func (r *Response) JSON() string {
+	jsonOutput, err := json.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(jsonOutput)
+}
+
+// YAML marshals the type into YAML format.
+func (r *Response) YAML() string {
+	yamlOutput, err := yaml.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(yamlOutput)
+}

--- a/pkg/wsman/ips/ipv6portsettings/settings.go
+++ b/pkg/wsman/ips/ipv6portsettings/settings.go
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package ipv6portsettings facilitates communication with Intel(R) AMT devices for IPS_IPv6PortSettings data.
+package ipv6portsettings
+
+import (
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/base"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+)
+
+type Settings struct {
+	base.WSManService[Response]
+}
+
+// NewIPv6PortSettingsWithClient creates a new IPS_IPv6PortSettings service.
+func NewIPv6PortSettingsWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) Settings {
+	return Settings{
+		base.NewService[Response](wsmanMessageCreator, IPSIPv6PortSettings, client),
+	}
+}

--- a/pkg/wsman/ips/ipv6portsettings/settings_test.go
+++ b/pkg/wsman/ips/ipv6portsettings/settings_test.go
@@ -1,0 +1,149 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package ipv6portsettings
+
+import (
+	"encoding/xml"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+func TestJson(t *testing.T) {
+	response := Response{
+		Body: Body{
+			PullResponse: PullResponse{},
+		},
+	}
+	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"GetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"CurrentDefaultRouter\":\"\",\"CurrentPrimaryDNS\":\"\",\"CurrentSecondaryDNS\":\"\",\"DefaultRouter\":\"\",\"ElementName\":\"\",\"IPv6Address\":\"\",\"InstanceID\":\"\",\"InterfaceIDType\":0,\"ManualInterfaceID\":\"\",\"PrimaryDNS\":\"\",\"SecondaryDNS\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"IPv6PortSettingsItems\":null},\"EnumerateResponse\":{\"EnumerationContext\":\"\"}}"
+	result := response.JSON()
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestYaml(t *testing.T) {
+	response := Response{
+		Body: Body{
+			PullResponse: PullResponse{},
+		},
+	}
+	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\ngetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    currentdefaultrouter: \"\"\n    currentprimarydns: \"\"\n    currentsecondarydns: \"\"\n    defaultrouter: \"\"\n    elementname: \"\"\n    ipv6address: \"\"\n    instanceid: \"\"\n    interfaceidtype: 0\n    manualinterfaceid: \"\"\n    primarydns: \"\"\n    secondarydns: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    ipv6portsettingsitems: []\nenumerateresponse:\n    enumerationcontext: \"\"\n"
+	result := response.YAML()
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestPositiveIPS_IPv6PortSettings(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.IPSResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{PackageUnderTest: "ips/ipv6portsettings"}
+	elementUnderTest := NewIPv6PortSettingsWithClient(wsmanMessageCreator, &client)
+
+	t.Run("ips_IPv6PortSettings Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			extraHeader      string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"should create a valid IPS_IPv6PortSettings Get wsman message",
+				IPSIPv6PortSettings,
+				wsmantesting.Get,
+				"",
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageGet
+
+					return elementUnderTest.Get()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					GetResponse: IPv6PortSettings{
+						XMLName:              xml.Name{Space: fmt.Sprintf("%s%s", message.IPSSchema, IPSIPv6PortSettings), Local: IPSIPv6PortSettings},
+						CurrentDefaultRouter: "::",
+						CurrentPrimaryDNS:    "::",
+						CurrentSecondaryDNS:  "::",
+						DefaultRouter:        "::",
+						ElementName:          "Intel(r) IPS IPv6 Settings 0",
+						IPv6Address:          "::",
+						InstanceID:           "Intel(r) IPS IPv6 Settings 0",
+						InterfaceIDType:      0,
+						ManualInterfaceID:    "0000000000000000",
+						PrimaryDNS:           "::",
+						SecondaryDNS:         "::",
+					},
+				},
+			},
+			{
+				"should create a valid IPS_IPv6PortSettings Enumerate wsman message",
+				IPSIPv6PortSettings,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName:           xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{EnumerationContext: "9C000000-0000-0000-0000-000000000000"},
+				},
+			},
+			{
+				"should create a valid IPS_IPv6PortSettings Pull wsman message",
+				IPSIPv6PortSettings,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: message.XMLPullResponseSpace, Local: "PullResponse"},
+						IPv6PortSettingsItems: []IPv6PortSettings{{
+							XMLName:              xml.Name{Space: fmt.Sprintf("%s%s", message.IPSSchema, IPSIPv6PortSettings), Local: IPSIPv6PortSettings},
+							CurrentDefaultRouter: "::",
+							CurrentPrimaryDNS:    "::",
+							CurrentSecondaryDNS:  "::",
+							DefaultRouter:        "::",
+							ElementName:          "Intel(r) IPS IPv6 Settings 0",
+							IPv6Address:          "::",
+							InstanceID:           "Intel(r) IPS IPv6 Settings 0",
+							InterfaceIDType:      0,
+							ManualInterfaceID:    "0000000000000000",
+							PrimaryDNS:           "::",
+							SecondaryDNS:         "::",
+						}},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, test.extraHeader, test.body)
+				messageID++
+				response, err := test.responseFunc()
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}

--- a/pkg/wsman/ips/ipv6portsettings/types.go
+++ b/pkg/wsman/ips/ipv6portsettings/types.go
@@ -1,0 +1,50 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package ipv6portsettings
+
+import (
+	"encoding/xml"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+)
+
+type (
+	Response struct {
+		*client.Message
+		XMLName xml.Name       `xml:"Envelope"`
+		Header  message.Header `xml:"Header"`
+		Body    Body           `xml:"Body"`
+	}
+
+	Body struct {
+		XMLName           xml.Name         `xml:"Body"`
+		GetResponse       IPv6PortSettings `xml:"IPS_IPv6PortSettings"`
+		PullResponse      PullResponse
+		EnumerateResponse common.EnumerateResponse
+	}
+
+	IPv6PortSettings struct {
+		XMLName              xml.Name `xml:"IPS_IPv6PortSettings"`
+		CurrentDefaultRouter string   `xml:"CurrentDefaultRouter,omitempty"`
+		CurrentPrimaryDNS    string   `xml:"CurrentPrimaryDNS,omitempty"`
+		CurrentSecondaryDNS  string   `xml:"CurrentSecondaryDNS,omitempty"`
+		DefaultRouter        string   `xml:"DefaultRouter,omitempty"`
+		ElementName          string   `xml:"ElementName,omitempty"`
+		IPv6Address          string   `xml:"IPv6Address,omitempty"`
+		InstanceID           string   `xml:"InstanceID,omitempty"`
+		InterfaceIDType      int      `xml:"InterfaceIDType"`
+		ManualInterfaceID    string   `xml:"ManualInterfaceID,omitempty"`
+		PrimaryDNS           string   `xml:"PrimaryDNS,omitempty"`
+		SecondaryDNS         string   `xml:"SecondaryDNS,omitempty"`
+	}
+
+	PullResponse struct {
+		XMLName               xml.Name           `xml:"PullResponse"`
+		IPv6PortSettingsItems []IPv6PortSettings `xml:"Items>IPS_IPv6PortSettings"`
+	}
+)

--- a/pkg/wsman/ips/lanendpoint/decoder.go
+++ b/pkg/wsman/ips/lanendpoint/decoder.go
@@ -1,0 +1,10 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package lanendpoint
+
+const (
+	IPSLANEndpoint string = "IPS_LANEndpoint"
+)

--- a/pkg/wsman/ips/lanendpoint/endpoint.go
+++ b/pkg/wsman/ips/lanendpoint/endpoint.go
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package lanendpoint facilitates communication with Intel(R) AMT devices for IPS_LANEndpoint data.
+package lanendpoint
+
+import (
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/base"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+)
+
+type Endpoint struct {
+	base.WSManService[Response]
+}
+
+// NewLANEndpointWithClient creates a new IPS_LANEndpoint service.
+func NewLANEndpointWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) Endpoint {
+	return Endpoint{
+		base.NewService[Response](wsmanMessageCreator, IPSLANEndpoint, client),
+	}
+}

--- a/pkg/wsman/ips/lanendpoint/endpoint_test.go
+++ b/pkg/wsman/ips/lanendpoint/endpoint_test.go
@@ -1,0 +1,145 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package lanendpoint
+
+import (
+	"encoding/xml"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+func TestJson(t *testing.T) {
+	response := Response{
+		Body: Body{
+			PullResponse: PullResponse{},
+		},
+	}
+	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"GetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"CreationClassName\":\"\",\"EnabledState\":0,\"LANType\":0,\"MACAddress\":\"\",\"Name\":\"\",\"ProtocolType\":0,\"RequestedState\":0,\"SystemCreationClassName\":\"\",\"SystemName\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"LANEndpointItems\":null},\"EnumerateResponse\":{\"EnumerationContext\":\"\"}}"
+	result := response.JSON()
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestYaml(t *testing.T) {
+	response := Response{
+		Body: Body{
+			PullResponse: PullResponse{},
+		},
+	}
+	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\ngetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    creationclassname: \"\"\n    enabledstate: 0\n    lantype: 0\n    macaddress: \"\"\n    name: \"\"\n    protocoltype: 0\n    requestedstate: 0\n    systemcreationclassname: \"\"\n    systemname: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    lanendpointitems: []\nenumerateresponse:\n    enumerationcontext: \"\"\n"
+	result := response.YAML()
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestPositiveIPS_LANEndpoint(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.IPSResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{PackageUnderTest: "ips/lanendpoint"}
+	elementUnderTest := NewLANEndpointWithClient(wsmanMessageCreator, &client)
+
+	t.Run("ips_LANEndpoint Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			extraHeader      string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"should create a valid IPS_LANEndpoint Get wsman message",
+				IPSLANEndpoint,
+				wsmantesting.Get,
+				"",
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageGet
+
+					return elementUnderTest.Get()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					GetResponse: LANEndpoint{
+						XMLName:                 xml.Name{Space: fmt.Sprintf("%s%s", message.IPSSchema, IPSLANEndpoint), Local: IPSLANEndpoint},
+						CreationClassName:       "IPS_LANEndpoint",
+						EnabledState:            2,
+						LANType:                 2,
+						MACAddress:              "48210b50d8c9",
+						Name:                    "Intel(r) AMT LAN Endpoint",
+						ProtocolType:            0,
+						RequestedState:          12,
+						SystemCreationClassName: "CIM_ComputerSystem",
+						SystemName:              "Intel(r) AMT",
+					},
+				},
+			},
+			{
+				"should create a valid IPS_LANEndpoint Enumerate wsman message",
+				IPSLANEndpoint,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName:           xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{EnumerationContext: "9D000000-0000-0000-0000-000000000000"},
+				},
+			},
+			{
+				"should create a valid IPS_LANEndpoint Pull wsman message",
+				IPSLANEndpoint,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: message.XMLPullResponseSpace, Local: "PullResponse"},
+						LANEndpointItems: []LANEndpoint{{
+							XMLName:                 xml.Name{Space: fmt.Sprintf("%s%s", message.IPSSchema, IPSLANEndpoint), Local: IPSLANEndpoint},
+							CreationClassName:       "IPS_LANEndpoint",
+							EnabledState:            2,
+							LANType:                 2,
+							MACAddress:              "48210b50d8c9",
+							Name:                    "Intel(r) AMT LAN Endpoint",
+							ProtocolType:            0,
+							RequestedState:          12,
+							SystemCreationClassName: "CIM_ComputerSystem",
+							SystemName:              "Intel(r) AMT",
+						}},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, test.extraHeader, test.body)
+				messageID++
+				response, err := test.responseFunc()
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}

--- a/pkg/wsman/ips/lanendpoint/marshal.go
+++ b/pkg/wsman/ips/lanendpoint/marshal.go
@@ -1,0 +1,32 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package lanendpoint
+
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+// JSON marshals the type into JSON format.
+func (r *Response) JSON() string {
+	jsonOutput, err := json.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(jsonOutput)
+}
+
+// YAML marshals the type into YAML format.
+func (r *Response) YAML() string {
+	yamlOutput, err := yaml.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(yamlOutput)
+}

--- a/pkg/wsman/ips/lanendpoint/types.go
+++ b/pkg/wsman/ips/lanendpoint/types.go
@@ -1,0 +1,48 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package lanendpoint
+
+import (
+	"encoding/xml"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+)
+
+type (
+	Response struct {
+		*client.Message
+		XMLName xml.Name       `xml:"Envelope"`
+		Header  message.Header `xml:"Header"`
+		Body    Body           `xml:"Body"`
+	}
+
+	Body struct {
+		XMLName           xml.Name    `xml:"Body"`
+		GetResponse       LANEndpoint `xml:"IPS_LANEndpoint"`
+		PullResponse      PullResponse
+		EnumerateResponse common.EnumerateResponse
+	}
+
+	LANEndpoint struct {
+		XMLName                 xml.Name `xml:"IPS_LANEndpoint"`
+		CreationClassName       string   `xml:"CreationClassName,omitempty"`
+		EnabledState            int      `xml:"EnabledState"`
+		LANType                 int      `xml:"LANType"`
+		MACAddress              string   `xml:"MACAddress,omitempty"`
+		Name                    string   `xml:"Name,omitempty"`
+		ProtocolType            int      `xml:"ProtocolType"`
+		RequestedState          int      `xml:"RequestedState"`
+		SystemCreationClassName string   `xml:"SystemCreationClassName,omitempty"`
+		SystemName              string   `xml:"SystemName,omitempty"`
+	}
+
+	PullResponse struct {
+		XMLName          xml.Name      `xml:"PullResponse"`
+		LANEndpointItems []LANEndpoint `xml:"Items>IPS_LANEndpoint"`
+	}
+)

--- a/pkg/wsman/ips/messages.go
+++ b/pkg/wsman/ips/messages.go
@@ -10,11 +10,16 @@ import (
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/alarmclock"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/hostbasedsetup"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/hostbootreason"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/hostipsettings"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/http"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ieee8021x"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ipv6portsettings"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/kvmredirection"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/lanendpoint"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/power"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/provisioningrecordlog"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/screensetting"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/secio"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
@@ -24,6 +29,11 @@ type Messages struct {
 	wsmanMessageCreator         *message.WSManMessageCreator
 	OptInService                optin.Service
 	HostBasedSetupService       hostbasedsetup.Service
+	HostBootReason              hostbootreason.Service
+	HostIPSettings              hostipsettings.Settings
+	IPv6PortSettings            ipv6portsettings.Settings
+	LANEndpoint                 lanendpoint.Endpoint
+	ProvisioningRecordLog       provisioningrecordlog.Log
 	AlarmClockOccurrence        alarmclock.Occurrence
 	IEEE8021xCredentialContext  ieee8021x.CredentialContext
 	IEEE8021xSettings           ieee8021x.Settings
@@ -43,6 +53,11 @@ func NewMessages(client client.WSMan) Messages {
 	}
 	m.OptInService = optin.NewOptInServiceWithClient(wsmanMessageCreator, client)
 	m.HostBasedSetupService = hostbasedsetup.NewHostBasedSetupServiceWithClient(wsmanMessageCreator, client)
+	m.HostBootReason = hostbootreason.NewHostBootReasonWithClient(wsmanMessageCreator, client)
+	m.HostIPSettings = hostipsettings.NewHostIPSettingsWithClient(wsmanMessageCreator, client)
+	m.IPv6PortSettings = ipv6portsettings.NewIPv6PortSettingsWithClient(wsmanMessageCreator, client)
+	m.LANEndpoint = lanendpoint.NewLANEndpointWithClient(wsmanMessageCreator, client)
+	m.ProvisioningRecordLog = provisioningrecordlog.NewProvisioningRecordLogWithClient(wsmanMessageCreator, client)
 	m.AlarmClockOccurrence = alarmclock.NewAlarmClockOccurrenceWithClient(wsmanMessageCreator, client)
 	m.IEEE8021xCredentialContext = ieee8021x.NewIEEE8021xCredentialContextWithClient(wsmanMessageCreator, client)
 	m.IEEE8021xSettings = ieee8021x.NewIEEE8021xSettingsWithClient(wsmanMessageCreator, client)

--- a/pkg/wsman/ips/messages_test.go
+++ b/pkg/wsman/ips/messages_test.go
@@ -11,10 +11,15 @@ import (
 
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/alarmclock"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/hostbasedsetup"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/hostbootreason"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/hostipsettings"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/http"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ieee8021x"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ipv6portsettings"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/lanendpoint"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/power"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/provisioningrecordlog"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
 )
 
@@ -32,6 +37,26 @@ func TestNewMessages(t *testing.T) {
 
 	if reflect.DeepEqual(m.HostBasedSetupService, hostbasedsetup.Service{}) {
 		t.Error("AuditLog is not initialized")
+	}
+
+	if reflect.DeepEqual(m.HostBootReason, hostbootreason.Service{}) {
+		t.Error("HostBootReason is not initialized")
+	}
+
+	if reflect.DeepEqual(m.HostIPSettings, hostipsettings.Settings{}) {
+		t.Error("HostIPSettings is not initialized")
+	}
+
+	if reflect.DeepEqual(m.IPv6PortSettings, ipv6portsettings.Settings{}) {
+		t.Error("IPv6PortSettings is not initialized")
+	}
+
+	if reflect.DeepEqual(m.LANEndpoint, lanendpoint.Endpoint{}) {
+		t.Error("LANEndpoint is not initialized")
+	}
+
+	if reflect.DeepEqual(m.ProvisioningRecordLog, provisioningrecordlog.Log{}) {
+		t.Error("ProvisioningRecordLog is not initialized")
 	}
 
 	if reflect.DeepEqual(m.AlarmClockOccurrence, alarmclock.Occurrence{}) {

--- a/pkg/wsman/ips/provisioningrecordlog/decoder.go
+++ b/pkg/wsman/ips/provisioningrecordlog/decoder.go
@@ -1,0 +1,10 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package provisioningrecordlog
+
+const (
+	IPSProvisioningRecordLog string = "IPS_ProvisioningRecordLog"
+)

--- a/pkg/wsman/ips/provisioningrecordlog/log.go
+++ b/pkg/wsman/ips/provisioningrecordlog/log.go
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package provisioningrecordlog facilitates communication with Intel(R) AMT devices for IPS_ProvisioningRecordLog data.
+package provisioningrecordlog
+
+import (
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/base"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+)
+
+type Log struct {
+	base.WSManService[Response]
+}
+
+// NewProvisioningRecordLogWithClient creates a new IPS_ProvisioningRecordLog service.
+func NewProvisioningRecordLogWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) Log {
+	return Log{
+		base.NewService[Response](wsmanMessageCreator, IPSProvisioningRecordLog, client),
+	}
+}

--- a/pkg/wsman/ips/provisioningrecordlog/log_test.go
+++ b/pkg/wsman/ips/provisioningrecordlog/log_test.go
@@ -1,0 +1,147 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package provisioningrecordlog
+
+import (
+	"encoding/xml"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+func TestJson(t *testing.T) {
+	response := Response{
+		Body: Body{
+			PullResponse: PullResponse{},
+		},
+	}
+	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"GetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"CurrentNumberOfRecords\":0,\"ElementName\":\"\",\"EnabledState\":0,\"HealthState\":0,\"InstanceID\":\"\",\"LogState\":0,\"MaxNumberOfRecords\":0,\"Name\":\"\",\"OverwritePolicy\":0,\"RequestedState\":0},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"ProvisioningRecordLogItems\":null},\"EnumerateResponse\":{\"EnumerationContext\":\"\"}}"
+	result := response.JSON()
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestYaml(t *testing.T) {
+	response := Response{
+		Body: Body{
+			PullResponse: PullResponse{},
+		},
+	}
+	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\ngetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    currentnumberofrecords: 0\n    elementname: \"\"\n    enabledstate: 0\n    healthstate: 0\n    instanceid: \"\"\n    logstate: 0\n    maxnumberofrecords: 0\n    name: \"\"\n    overwritepolicy: 0\n    requestedstate: 0\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    provisioningrecordlogitems: []\nenumerateresponse:\n    enumerationcontext: \"\"\n"
+	result := response.YAML()
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestPositiveIPS_ProvisioningRecordLog(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.IPSResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{PackageUnderTest: "ips/provisioningrecordlog"}
+	elementUnderTest := NewProvisioningRecordLogWithClient(wsmanMessageCreator, &client)
+
+	t.Run("ips_ProvisioningRecordLog Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			extraHeader      string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"should create a valid IPS_ProvisioningRecordLog Get wsman message",
+				IPSProvisioningRecordLog,
+				wsmantesting.Get,
+				"",
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageGet
+
+					return elementUnderTest.Get()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					GetResponse: ProvisioningRecordLog{
+						XMLName:                xml.Name{Space: fmt.Sprintf("%s%s", message.IPSSchema, IPSProvisioningRecordLog), Local: IPSProvisioningRecordLog},
+						CurrentNumberOfRecords: 1,
+						ElementName:            "Intel(r) AMT Provisioning Record Log",
+						EnabledState:           2,
+						HealthState:            0,
+						InstanceID:             "Intel(r) AMT: RecordLog 1",
+						LogState:               4,
+						MaxNumberOfRecords:     1,
+						Name:                   "Intel(r) AMT Provisioning Record Log",
+						OverwritePolicy:        2,
+						RequestedState:         12,
+					},
+				},
+			},
+			{
+				"should create a valid IPS_ProvisioningRecordLog Enumerate wsman message",
+				IPSProvisioningRecordLog,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName:           xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{EnumerationContext: "17000000-0000-0000-0000-000000000000"},
+				},
+			},
+			{
+				"should create a valid IPS_ProvisioningRecordLog Pull wsman message",
+				IPSProvisioningRecordLog,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: message.XMLPullResponseSpace, Local: "PullResponse"},
+						ProvisioningRecordLogItems: []ProvisioningRecordLog{{
+							XMLName:                xml.Name{Space: fmt.Sprintf("%s%s", message.IPSSchema, IPSProvisioningRecordLog), Local: IPSProvisioningRecordLog},
+							CurrentNumberOfRecords: 1,
+							ElementName:            "Intel(r) AMT Provisioning Record Log",
+							EnabledState:           2,
+							HealthState:            0,
+							InstanceID:             "Intel(r) AMT: RecordLog 1",
+							LogState:               4,
+							MaxNumberOfRecords:     1,
+							Name:                   "Intel(r) AMT Provisioning Record Log",
+							OverwritePolicy:        2,
+							RequestedState:         12,
+						}},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, test.extraHeader, test.body)
+				messageID++
+				response, err := test.responseFunc()
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}

--- a/pkg/wsman/ips/provisioningrecordlog/marshal.go
+++ b/pkg/wsman/ips/provisioningrecordlog/marshal.go
@@ -1,0 +1,32 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package provisioningrecordlog
+
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+// JSON marshals the type into JSON format.
+func (r *Response) JSON() string {
+	jsonOutput, err := json.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(jsonOutput)
+}
+
+// YAML marshals the type into YAML format.
+func (r *Response) YAML() string {
+	yamlOutput, err := yaml.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(yamlOutput)
+}

--- a/pkg/wsman/ips/provisioningrecordlog/types.go
+++ b/pkg/wsman/ips/provisioningrecordlog/types.go
@@ -1,0 +1,49 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package provisioningrecordlog
+
+import (
+	"encoding/xml"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+)
+
+type (
+	Response struct {
+		*client.Message
+		XMLName xml.Name       `xml:"Envelope"`
+		Header  message.Header `xml:"Header"`
+		Body    Body           `xml:"Body"`
+	}
+
+	Body struct {
+		XMLName           xml.Name              `xml:"Body"`
+		GetResponse       ProvisioningRecordLog `xml:"IPS_ProvisioningRecordLog"`
+		PullResponse      PullResponse
+		EnumerateResponse common.EnumerateResponse
+	}
+
+	ProvisioningRecordLog struct {
+		XMLName                xml.Name `xml:"IPS_ProvisioningRecordLog"`
+		CurrentNumberOfRecords int      `xml:"CurrentNumberOfRecords"`
+		ElementName            string   `xml:"ElementName,omitempty"`
+		EnabledState           int      `xml:"EnabledState"`
+		HealthState            int      `xml:"HealthState"`
+		InstanceID             string   `xml:"InstanceID,omitempty"`
+		LogState               int      `xml:"LogState"`
+		MaxNumberOfRecords     int      `xml:"MaxNumberOfRecords"`
+		Name                   string   `xml:"Name,omitempty"`
+		OverwritePolicy        int      `xml:"OverwritePolicy"`
+		RequestedState         int      `xml:"RequestedState"`
+	}
+
+	PullResponse struct {
+		XMLName                    xml.Name                `xml:"PullResponse"`
+		ProvisioningRecordLogItems []ProvisioningRecordLog `xml:"Items>IPS_ProvisioningRecordLog"`
+	}
+)

--- a/pkg/wsman/wsmantesting/responses/ips/hostbootreason/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/hostbootreason/enumerate.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>1</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+        <b:MessageID>uuid:00000000-0000-0000-0000-000000000293</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostBootReason</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:EnumerateResponse>
+            <g:EnumerationContext>97000000-0000-0000-0000-000000000000</g:EnumerationContext>
+        </g:EnumerateResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/hostbootreason/get.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/hostbootreason/get.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostBootReason"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>0</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</b:Action>
+            <b:MessageID>uuid:00000000-0000-0000-0000-000000000292</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostBootReason</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:IPS_HostBootReason>
+            <g:ElementName>Intel(r) AMT:Host Boot Reason</g:ElementName>
+            <g:InstanceID>Intel(r) AMT:Host Boot Reason</g:InstanceID>
+            <g:PreviousSxState>0</g:PreviousSxState>
+            <g:Reason>1</g:Reason>
+            <g:ReasonDetails></g:ReasonDetails>
+        </g:IPS_HostBootReason>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/hostbootreason/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/hostbootreason/pull.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:h="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostBootReason"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>2</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+        <b:MessageID>uuid:00000000-0000-0000-0000-000000000294</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostBootReason</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:PullResponse>
+            <g:Items>
+                <h:IPS_HostBootReason>
+                    <h:ElementName>Intel(r) AMT:Host Boot Reason</h:ElementName>
+                    <h:InstanceID>Intel(r) AMT:Host Boot Reason</h:InstanceID>
+                    <h:PreviousSxState>0</h:PreviousSxState>
+                    <h:Reason>1</h:Reason>
+                    <h:ReasonDetails></h:ReasonDetails>
+                </h:IPS_HostBootReason>
+            </g:Items>
+            <g:EndOfSequence></g:EndOfSequence>
+        </g:PullResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/hostipsettings/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/hostipsettings/enumerate.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>1</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-00000000029D</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostIPSettings</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:EnumerateResponse>
+            <g:EnumerationContext>9A000000-0000-0000-0000-000000000000</g:EnumerationContext>
+        </g:EnumerateResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/hostipsettings/get.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/hostipsettings/get.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostIPSettings"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>0</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-00000000029C</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostIPSettings</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:IPS_HostIPSettings>
+            <g:DHCPEnabled>false</g:DHCPEnabled>
+            <g:ElementName>Intel(r) AMT: Host IP Settings</g:ElementName>
+            <g:InstanceID>Intel(r) AMT: Host IP Settings</g:InstanceID>
+        </g:IPS_HostIPSettings>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/hostipsettings/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/hostipsettings/pull.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:h="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostIPSettings"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>2</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-00000000029E</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostIPSettings</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:PullResponse>
+            <g:Items>
+                <h:IPS_HostIPSettings>
+                    <h:DHCPEnabled>false</h:DHCPEnabled>
+                    <h:ElementName>Intel(r) AMT: Host IP Settings</h:ElementName>
+                    <h:InstanceID>Intel(r) AMT: Host IP Settings</h:InstanceID>
+                </h:IPS_HostIPSettings>
+            </g:Items>
+            <g:EndOfSequence></g:EndOfSequence>
+        </g:PullResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/ipv6portsettings/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/ipv6portsettings/enumerate.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>1</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-0000000002A2</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_IPv6PortSettings</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:EnumerateResponse>
+            <g:EnumerationContext>9C000000-0000-0000-0000-000000000000</g:EnumerationContext>
+        </g:EnumerateResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/ipv6portsettings/get.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/ipv6portsettings/get.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_IPv6PortSettings"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>0</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-0000000002A1</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_IPv6PortSettings</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:IPS_IPv6PortSettings>
+            <g:CurrentDefaultRouter>::</g:CurrentDefaultRouter>
+            <g:CurrentPrimaryDNS>::</g:CurrentPrimaryDNS>
+            <g:CurrentSecondaryDNS>::</g:CurrentSecondaryDNS>
+            <g:DefaultRouter>::</g:DefaultRouter>
+            <g:ElementName>Intel(r) IPS IPv6 Settings 0</g:ElementName>
+            <g:IPv6Address>::</g:IPv6Address>
+            <g:InstanceID>Intel(r) IPS IPv6 Settings 0</g:InstanceID>
+            <g:InterfaceIDType>0</g:InterfaceIDType>
+            <g:ManualInterfaceID>0000000000000000</g:ManualInterfaceID>
+            <g:PrimaryDNS>::</g:PrimaryDNS>
+            <g:SecondaryDNS>::</g:SecondaryDNS>
+        </g:IPS_IPv6PortSettings>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/ipv6portsettings/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/ipv6portsettings/pull.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:h="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_IPv6PortSettings"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>2</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-0000000002A3</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_IPv6PortSettings</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:PullResponse>
+            <g:Items>
+                <h:IPS_IPv6PortSettings>
+                    <h:CurrentDefaultRouter>::</h:CurrentDefaultRouter>
+                    <h:CurrentPrimaryDNS>::</h:CurrentPrimaryDNS>
+                    <h:CurrentSecondaryDNS>::</h:CurrentSecondaryDNS>
+                    <h:DefaultRouter>::</h:DefaultRouter>
+                    <h:ElementName>Intel(r) IPS IPv6 Settings 0</h:ElementName>
+                    <h:IPv6Address>::</h:IPv6Address>
+                    <h:InstanceID>Intel(r) IPS IPv6 Settings 0</h:InstanceID>
+                    <h:InterfaceIDType>0</h:InterfaceIDType>
+                    <h:ManualInterfaceID>0000000000000000</h:ManualInterfaceID>
+                    <h:PrimaryDNS>::</h:PrimaryDNS>
+                    <h:SecondaryDNS>::</h:SecondaryDNS>
+                </h:IPS_IPv6PortSettings>
+            </g:Items>
+            <g:EndOfSequence></g:EndOfSequence>
+        </g:PullResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/lanendpoint/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/lanendpoint/enumerate.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>1</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-0000000002A5</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_LANEndpoint</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:EnumerateResponse>
+            <g:EnumerationContext>9D000000-0000-0000-0000-000000000000</g:EnumerationContext>
+        </g:EnumerateResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/lanendpoint/get.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/lanendpoint/get.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_LANEndpoint"
+    xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/common"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>0</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-0000000002A4</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_LANEndpoint</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:IPS_LANEndpoint>
+            <g:CreationClassName>IPS_LANEndpoint</g:CreationClassName>
+            <g:EnabledState>2</g:EnabledState>
+            <g:LANType>2</g:LANType>
+            <g:MACAddress>48210b50d8c9</g:MACAddress>
+            <g:Name>Intel(r) AMT LAN Endpoint</g:Name>
+            <g:ProtocolType>0</g:ProtocolType>
+            <g:RequestedState>12</g:RequestedState>
+            <g:SystemCreationClassName>CIM_ComputerSystem</g:SystemCreationClassName>
+            <g:SystemName>Intel(r) AMT</g:SystemName>
+        </g:IPS_LANEndpoint>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/lanendpoint/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/lanendpoint/pull.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:h="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_LANEndpoint"
+    xmlns:i="http://schemas.dmtf.org/wbem/wscim/1/common"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>2</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-0000000002A6</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_LANEndpoint</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:PullResponse>
+            <g:Items>
+                <h:IPS_LANEndpoint>
+                    <h:CreationClassName>IPS_LANEndpoint</h:CreationClassName>
+                    <h:EnabledState>2</h:EnabledState>
+                    <h:LANType>2</h:LANType>
+                    <h:MACAddress>48210b50d8c9</h:MACAddress>
+                    <h:Name>Intel(r) AMT LAN Endpoint</h:Name>
+                    <h:ProtocolType>0</h:ProtocolType>
+                    <h:RequestedState>12</h:RequestedState>
+                    <h:SystemCreationClassName>CIM_ComputerSystem</h:SystemCreationClassName>
+                    <h:SystemName>Intel(r) AMT</h:SystemName>
+                </h:IPS_LANEndpoint>
+            </g:Items>
+            <g:EndOfSequence></g:EndOfSequence>
+        </g:PullResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/provisioningrecordlog/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/provisioningrecordlog/enumerate.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>1</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000065</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_ProvisioningRecordLog</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:EnumerateResponse>
+            <g:EnumerationContext>17000000-0000-0000-0000-000000000000</g:EnumerationContext>
+        </g:EnumerateResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/provisioningrecordlog/get.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/provisioningrecordlog/get.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_ProvisioningRecordLog"
+    xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/common"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>0</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000064</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_ProvisioningRecordLog</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:IPS_ProvisioningRecordLog>
+            <g:CurrentNumberOfRecords>1</g:CurrentNumberOfRecords>
+            <g:ElementName>Intel(r) AMT Provisioning Record Log</g:ElementName>
+            <g:EnabledState>2</g:EnabledState>
+            <g:HealthState>0</g:HealthState>
+            <g:InstanceID>Intel(r) AMT: RecordLog 1</g:InstanceID>
+            <g:LogState>4</g:LogState>
+            <g:MaxNumberOfRecords>1</g:MaxNumberOfRecords>
+            <g:Name>Intel(r) AMT Provisioning Record Log</g:Name>
+            <g:OverwritePolicy>2</g:OverwritePolicy>
+            <g:RequestedState>12</g:RequestedState>
+        </g:IPS_ProvisioningRecordLog>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/ips/provisioningrecordlog/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/ips/provisioningrecordlog/pull.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:h="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_ProvisioningRecordLog"
+    xmlns:i="http://schemas.dmtf.org/wbem/wscim/1/common"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>2</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000066</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_ProvisioningRecordLog</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:PullResponse>
+            <g:Items>
+                <h:IPS_ProvisioningRecordLog>
+                    <h:CurrentNumberOfRecords>1</h:CurrentNumberOfRecords>
+                    <h:ElementName>Intel(r) AMT Provisioning Record Log</h:ElementName>
+                    <h:EnabledState>2</h:EnabledState>
+                    <h:HealthState>0</h:HealthState>
+                    <h:InstanceID>Intel(r) AMT: RecordLog 1</h:InstanceID>
+                    <h:LogState>4</h:LogState>
+                    <h:MaxNumberOfRecords>1</h:MaxNumberOfRecords>
+                    <h:Name>Intel(r) AMT Provisioning Record Log</h:Name>
+                    <h:OverwritePolicy>2</h:OverwritePolicy>
+                    <h:RequestedState>12</h:RequestedState>
+                </h:IPS_ProvisioningRecordLog>
+            </g:Items>
+            <g:EndOfSequence></g:EndOfSequence>
+        </g:PullResponse>
+    </a:Body>
+</a:Envelope>


### PR DESCRIPTION
- Add new package with service, types, decoder, and JSON/YAML marshalling
- Add unit tests for the newly added package

Packages Included -
	- IPS_HostBootReason
	- IPS_HostIPSettings
	- IPS_IPv6PortSettings
	- IPS_LANEndpoint
	- IPS_ProvisioningRecordLog