### PR TITLE
refactor: add missing wsman fetcher class function for CIM classes

### DIFF
--- a/pkg/wsman/cim/bios/decoder.go
+++ b/pkg/wsman/cim/bios/decoder.go
@@ -7,6 +7,7 @@ package bios
 
 const (
 	CIMBIOSElement string = "CIM_BIOSElement"
+	CIMBIOSFeature string = "CIM_BIOSFeature"
 	ValueNotFound  string = "Value not found in map"
 )
 

--- a/pkg/wsman/cim/bios/element_test.go
+++ b/pkg/wsman/cim/bios/element_test.go
@@ -19,10 +19,10 @@ import (
 func TestJson(t *testing.T) {
 	response := Response{
 		Body: Body{
-			GetResponse: BiosElement{},
+			BIOSElementGetResponse: BiosElement{},
 		},
 	}
-	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"GetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"TargetOperatingSystem\":0,\"SoftwareElementID\":\"\",\"SoftwareElementState\":0,\"Name\":\"\",\"OperationalStatus\":null,\"ElementName\":\"\",\"Version\":\"\",\"Manufacturer\":\"\",\"PrimaryBIOS\":false,\"ReleaseDate\":{\"DateTime\":\"\"}},\"EnumerateResponse\":{\"EnumerationContext\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"BiosElementItems\":null}}"
+	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"BIOSElementGetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"TargetOperatingSystem\":0,\"SoftwareElementID\":\"\",\"SoftwareElementState\":0,\"Name\":\"\",\"OperationalStatus\":null,\"ElementName\":\"\",\"Version\":\"\",\"Manufacturer\":\"\",\"PrimaryBIOS\":false,\"ReleaseDate\":{\"DateTime\":\"\"}},\"BIOSFeatureGetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"Name\":\"\",\"ElementName\":\"\",\"Characteristics\":null,\"IdentifyingNumber\":\"\",\"ProductName\":\"\",\"Vendor\":\"\",\"Version\":\"\",\"OperationalStatus\":null},\"EnumerateResponse\":{\"EnumerationContext\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"BiosElementItems\":null,\"BIOSFeatureItems\":null}}"
 	result := response.JSON()
 	assert.Equal(t, expectedResult, result)
 }
@@ -30,10 +30,10 @@ func TestJson(t *testing.T) {
 func TestYaml(t *testing.T) {
 	response := Response{
 		Body: Body{
-			GetResponse: BiosElement{},
+			BIOSElementGetResponse: BiosElement{},
 		},
 	}
-	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\ngetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    targetoperatingsystem: 0\n    softwareelementid: \"\"\n    softwareelementstate: 0\n    name: \"\"\n    operationalstatus: []\n    elementname: \"\"\n    version: \"\"\n    manufacturer: \"\"\n    primarybios: false\n    releasedate:\n        datetime: \"\"\nenumerateresponse:\n    enumerationcontext: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    bioselementitems: []\n"
+	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\nbioselementgetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    targetoperatingsystem: 0\n    softwareelementid: \"\"\n    softwareelementstate: 0\n    name: \"\"\n    operationalstatus: []\n    elementname: \"\"\n    version: \"\"\n    manufacturer: \"\"\n    primarybios: false\n    releasedate:\n        datetime: \"\"\nbiosfeaturegetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    name: \"\"\n    elementname: \"\"\n    characteristics: []\n    identifyingnumber: \"\"\n    productname: \"\"\n    vendor: \"\"\n    version: \"\"\n    operationalstatus: []\nenumerateresponse:\n    enumerationcontext: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    bioselementitems: []\n    biosfeatureitems: []\n"
 	result := response.YAML()
 	assert.Equal(t, expectedResult, result)
 }
@@ -69,7 +69,7 @@ func TestPositiveCIMBIOSElement(t *testing.T) {
 				},
 				Body{
 					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
-					GetResponse: BiosElement{
+					BIOSElementGetResponse: BiosElement{
 						XMLName:               xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BIOSElement", Local: CIMBIOSElement},
 						TargetOperatingSystem: 66,
 						SoftwareElementID:     "QNCFLX70.0054.2020.0810.2227",
@@ -181,7 +181,7 @@ func TestNegativeCIMBIOSElement(t *testing.T) {
 				},
 				Body{
 					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
-					GetResponse: BiosElement{
+					BIOSElementGetResponse: BiosElement{
 						XMLName:               xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BIOSElement", Local: CIMBIOSElement},
 						TargetOperatingSystem: 66,
 						SoftwareElementID:     "QNCFLX70.0054.2020.0810.2227",

--- a/pkg/wsman/cim/bios/feature.go
+++ b/pkg/wsman/cim/bios/feature.go
@@ -1,0 +1,73 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package bios facilitates communication with Intel(R) AMT devices to get information about BIOS features.
+package bios
+
+import (
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/base"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+)
+
+// FWData holds captured firmware XML responses for testing/recording purposes.
+type FWData struct {
+	GetXML       string
+	EnumerateXML string
+	PullXML      string
+	PutXML       string
+}
+
+type Feature struct {
+	base.WSManService[Response]
+}
+
+// NewBIOSFeatureWithClient instantiates a new Feature.
+func NewBIOSFeatureWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) Feature {
+	return Feature{
+		base.NewService[Response](wsmanMessageCreator, CIMBIOSFeature, client),
+	}
+}
+
+// FetchFWData captures the XML from Get, Enumerate, Pull (and optionally Put) operations.
+func (f Feature) FetchFWData(request PutRequest) (FWData, error) {
+	var fwData FWData
+
+	enumerateResponse, err := f.Enumerate()
+	if err != nil {
+		return fwData, err
+	}
+
+	fwData.EnumerateXML = enumerateResponse.XMLOutput
+
+	pullResponse, err := f.Pull(enumerateResponse.Body.EnumerateResponse.EnumerationContext)
+	if err != nil {
+		return fwData, err
+	}
+
+	fwData.PullXML = pullResponse.XMLOutput
+
+	getResponse, err := f.Get()
+	if err != nil {
+		return fwData, err
+	}
+
+	fwData.GetXML = getResponse.XMLOutput
+
+	if request.FeatureName != "" {
+		feature := BIOSFeature{
+			Name: request.FeatureName,
+		}
+
+		putResponse, err := f.Put(feature)
+		if err != nil {
+			return fwData, err
+		}
+
+		fwData.PutXML = putResponse.XMLOutput
+	}
+
+	return fwData, nil
+}

--- a/pkg/wsman/cim/bios/feature_test.go
+++ b/pkg/wsman/cim/bios/feature_test.go
@@ -1,0 +1,171 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package bios
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+func TestPositiveCIMBIOSFeature(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/bios/feature",
+	}
+	elementUnderTest := NewBIOSFeatureWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_BIOSFeature Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"should create and parse a valid CIM_BIOSFeature Get call",
+				CIMBIOSFeature,
+				wsmantesting.Get,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageGet
+
+					return elementUnderTest.Get()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					BIOSFeatureGetResponse: BIOSFeature{
+						XMLName:           xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BIOSFeature", Local: CIMBIOSFeature},
+						Name:              "Primary BIOS Features",
+						ElementName:       "Primary BIOS Features",
+						Characteristics:   []string{"7", "11", "12", "27", "28", "29", "31"},
+						IdentifyingNumber: "M46580-303",
+						ProductName:       "NUC12WSHv5",
+						Vendor:            "Intel(R) Client Systems",
+						Version:           "M46580-303",
+						OperationalStatus: []OperationalStatus{0},
+					},
+				},
+			},
+			{
+				"should create a valid CIM_BIOSFeature Enumerate call",
+				CIMBIOSFeature,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{
+						EnumerationContext: "2D000000-0000-0000-0000-000000000000",
+					},
+				},
+			},
+			{
+				"should create a valid CIM_BIOSFeature Pull call",
+				CIMBIOSFeature,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: "http://schemas.xmlsoap.org/ws/2004/09/enumeration", Local: "PullResponse"},
+						BIOSFeatureItems: []BIOSFeature{
+							{
+								XMLName:           xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BIOSFeature", Local: CIMBIOSFeature},
+								Name:              "Primary BIOS Features",
+								ElementName:       "Primary BIOS Features",
+								Characteristics:   []string{"7", "11", "12", "27", "28", "29", "31"},
+								IdentifyingNumber: "M46580-303",
+								ProductName:       "NUC12WSHv5",
+								Vendor:            "Intel(R) Client Systems",
+								Version:           "M46580-303",
+								OperationalStatus: []OperationalStatus{0},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, "", test.body)
+				messageID++
+				response, err := test.responseFunc()
+
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}
+
+func TestNegativeCIMBIOSFeature(t *testing.T) {
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/bios/feature",
+	}
+	elementUnderTest := NewBIOSFeatureWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_BIOSFeature Error Handling Tests", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			responseFunc func() (Response, error)
+		}{
+			{
+				"should handle error when Get fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Get()
+				},
+			},
+			{
+				"should handle error when Enumerate fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Enumerate()
+				},
+			},
+			{
+				"should handle error when Pull fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := test.responseFunc()
+				assert.Error(t, err)
+			})
+		}
+	})
+}

--- a/pkg/wsman/cim/bios/types.go
+++ b/pkg/wsman/cim/bios/types.go
@@ -23,10 +23,11 @@ type (
 	}
 
 	Body struct {
-		XMLName           xml.Name `xml:"Body"`
-		GetResponse       BiosElement
-		EnumerateResponse common.EnumerateResponse
-		PullResponse      PullResponse
+		XMLName                xml.Name    `xml:"Body"`
+		BIOSElementGetResponse BiosElement `xml:"CIM_BIOSElement"`
+		BIOSFeatureGetResponse BIOSFeature `xml:"CIM_BIOSFeature"`
+		EnumerateResponse      common.EnumerateResponse
+		PullResponse           PullResponse
 	}
 
 	BiosElement struct {
@@ -47,9 +48,27 @@ type (
 		DateTime string `xml:"Datetime"`
 	}
 
+	BIOSFeature struct {
+		XMLName           xml.Name            `xml:"CIM_BIOSFeature"`
+		Name              string              `xml:"Name"`              // The label by which the object is known.
+		ElementName       string              `xml:"ElementName"`       // A user-friendly name for the object.
+		Characteristics   []string            `xml:"Characteristics"`   // BIOS feature characteristics reported by the device.
+		IdentifyingNumber string              `xml:"IdentifyingNumber"` // Product identifier assigned by the manufacturer.
+		ProductName       string              `xml:"ProductName"`       // Product name of the BIOS feature.
+		Vendor            string              `xml:"Vendor"`            // Vendor of the BIOS feature.
+		Version           string              `xml:"Version"`           // Version of the BIOS feature.
+		OperationalStatus []OperationalStatus `xml:"OperationalStatus"` // Current statuses of the element.
+	}
+
 	PullResponse struct {
 		XMLName          xml.Name      `xml:"PullResponse"`
 		BiosElementItems []BiosElement `xml:"Items>CIM_BIOSElement"`
+		BIOSFeatureItems []BIOSFeature `xml:"Items>CIM_BIOSFeature"`
+	}
+
+	// PutRequest is used to modify a BIOSFeature instance.
+	PutRequest struct {
+		FeatureName string
 	}
 
 	// TargetOperatingSystem is the element's operating system environment.

--- a/pkg/wsman/cim/ethernetport/decoder.go
+++ b/pkg/wsman/cim/ethernetport/decoder.go
@@ -1,0 +1,11 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package ethernetport
+
+const (
+	CIMEthernetPort string = "CIM_EthernetPort"
+	ValueNotFound   string = "Value not found in map"
+)

--- a/pkg/wsman/cim/ethernetport/marshal.go
+++ b/pkg/wsman/cim/ethernetport/marshal.go
@@ -1,0 +1,32 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package ethernetport
+
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+// JSON marshals the type into JSON format.
+func (r *Response) JSON() string {
+	jsonOutput, err := json.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(jsonOutput)
+}
+
+// YAML marshals the type into YAML format.
+func (r *Response) YAML() string {
+	yamlOutput, err := yaml.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(yamlOutput)
+}

--- a/pkg/wsman/cim/ethernetport/port.go
+++ b/pkg/wsman/cim/ethernetport/port.go
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package ethernetport facilitates communication with Intel® AMT devices to access CIM_EthernetPort data.
+package ethernetport
+
+import (
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/base"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+)
+
+type Port struct {
+	base.WSManService[Response]
+}
+
+// NewEthernetPortWithClient instantiates a new EthernetPort service.
+func NewEthernetPortWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) Port {
+	return Port{
+		base.NewService[Response](wsmanMessageCreator, CIMEthernetPort, client),
+	}
+}

--- a/pkg/wsman/cim/ethernetport/port_test.go
+++ b/pkg/wsman/cim/ethernetport/port_test.go
@@ -1,0 +1,185 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package ethernetport
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+func TestPositiveCIMEthernetPort(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/ethernetport",
+	}
+	elementUnderTest := NewEthernetPortWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_EthernetPort Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"should create and parse a valid CIM_EthernetPort Get call",
+				CIMEthernetPort,
+				wsmantesting.Get,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageGet
+
+					return elementUnderTest.Get()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					GetResponse: EthernetPort{
+						XMLName:                 xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_EthernetPort", Local: CIMEthernetPort},
+						DeviceID:                "Intel(r) AMT Ethernet Port 0",
+						CreationClassName:       "CIM_EthernetPort",
+						SystemName:              "Intel(r) AMT",
+						SystemCreationClassName: "CIM_ComputerSystem",
+						ElementName:             "Intel(r) AMT Ethernet Port",
+						Description:             "Wired0",
+						EnabledState:            2,
+						EnabledDefault:          5,
+						RequestedState:          12,
+						OperationalStatus:       []int{0},
+						LinkTechnology:          2,
+						NetworkAddresses:        []string{"48210b50d8c9"},
+						Speed:                   1000000000,
+						MaxSpeed:                2500000000,
+						PortType:                53,
+					},
+				},
+			},
+			{
+				"should create a valid CIM_EthernetPort Enumerate call",
+				CIMEthernetPort,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{
+						EnumerationContext: "2E000000-0000-0000-0000-000000000000",
+					},
+				},
+			},
+			{
+				"should create a valid CIM_EthernetPort Pull call",
+				CIMEthernetPort,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: "http://schemas.xmlsoap.org/ws/2004/09/enumeration", Local: "PullResponse"},
+						EthernetPortItems: []EthernetPort{
+							{
+								XMLName:                 xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_EthernetPort", Local: CIMEthernetPort},
+								DeviceID:                "Intel(r) AMT Ethernet Port 0",
+								CreationClassName:       "CIM_EthernetPort",
+								SystemName:              "Intel(r) AMT",
+								SystemCreationClassName: "CIM_ComputerSystem",
+								ElementName:             "Intel(r) AMT Ethernet Port",
+								Description:             "Wired0",
+								EnabledState:            2,
+								EnabledDefault:          5,
+								RequestedState:          12,
+								OperationalStatus:       []int{0},
+								LinkTechnology:          2,
+								NetworkAddresses:        []string{"48210b50d8c9"},
+								Speed:                   1000000000,
+								MaxSpeed:                2500000000,
+								PortType:                53,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, "", test.body)
+				messageID++
+				response, err := test.responseFunc()
+
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}
+
+func TestNegativeCIMEthernetPort(t *testing.T) {
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/ethernetport",
+	}
+	elementUnderTest := NewEthernetPortWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_EthernetPort Error Handling Tests", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			responseFunc func() (Response, error)
+		}{
+			{
+				"should handle error when Get fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Get()
+				},
+			},
+			{
+				"should handle error when Enumerate fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Enumerate()
+				},
+			},
+			{
+				"should handle error when Pull fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := test.responseFunc()
+				assert.Error(t, err)
+			})
+		}
+	})
+}

--- a/pkg/wsman/cim/ethernetport/types.go
+++ b/pkg/wsman/cim/ethernetport/types.go
@@ -1,0 +1,67 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package ethernetport
+
+import (
+	"encoding/xml"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+)
+
+// Response Types.
+type (
+	Response struct {
+		*client.Message
+		XMLName xml.Name       `xml:"Envelope"`
+		Header  message.Header `xml:"Header"`
+		Body    Body           `xml:"Body"`
+	}
+
+	Body struct {
+		XMLName           xml.Name `xml:"Body"`
+		GetResponse       EthernetPort
+		EnumerateResponse common.EnumerateResponse
+		PullResponse      PullResponse
+	}
+
+	EthernetPort struct {
+		XMLName                 xml.Name       `xml:"CIM_EthernetPort"`
+		DeviceID                string         `xml:"DeviceID"`                    // An address or other identifying information to uniquely name the LogicalDevice.
+		CreationClassName       string         `xml:"CreationClassName"`           // CreationClassName indicates the name of the class or the subclass used in the creation of an instance.
+		SystemName              string         `xml:"SystemName"`                  // The scoping System's Name.
+		SystemCreationClassName string         `xml:"SystemCreationClassName"`     // The scoping System's CreationClassName.
+		ElementName             string         `xml:"ElementName"`                 // A user-friendly name for the object.
+		Description             string         `xml:"Description,omitempty"`       // A textual description of the EthernetPort.
+		EnabledState            EnabledState   `xml:"EnabledState,omitempty"`      // EnabledState is an integer enumeration that indicates the enabled and disabled states of an element.
+		EnabledDefault          uint16         `xml:"EnabledDefault,omitempty"`    // EnabledDefault is an administrator's default or startup configuration for the enabled state of the element.
+		RequestedState          RequestedState `xml:"RequestedState,omitempty"`    // RequestedState is an integer enumeration that indicates the last requested or desired state for the element.
+		OperationalStatus       []int          `xml:"OperationalStatus,omitempty"` // OperationalStatus indicates the current statuses of the element.
+		LinkTechnology          LinkTechnology `xml:"LinkTechnology,omitempty"`    // An enumeration of the types of links.
+		PermanentAddress        string         `xml:"PermanentAddress,omitempty"`  // The IEEE 802 EUI-48 MAC address.
+		NetworkAddresses        []string       `xml:"NetworkAddresses,omitempty"`  // NetworkAddresses lists the network addresses for the port.
+		Speed                   uint64         `xml:"Speed,omitempty"`             // The current bandwidth of the Port in Bits per Second.
+		MaxSpeed                uint64         `xml:"MaxSpeed,omitempty"`          // The maximum bandwidth of the Port in Bits per Second.
+		PortType                PortType       `xml:"PortType,omitempty"`          // The specific mode that is currently enabled on the Port.
+		MaxDataSize             uint32         `xml:"MaxDataSize,omitempty"`       // The maximum size of the INFO (non-MAC) field that will be received or transmitted.
+		Capabilities            []int          `xml:"Capabilities,omitempty"`      // Capabilities of the EthernetPort.
+	}
+
+	PullResponse struct {
+		XMLName           xml.Name       `xml:"PullResponse"`
+		EthernetPortItems []EthernetPort `xml:"Items>CIM_EthernetPort"`
+	}
+
+	// EnabledState is an integer enumeration that indicates the enabled and disabled states of an element.
+	EnabledState int
+	// RequestedState is an integer enumeration that indicates the last requested or desired state for the element.
+	RequestedState int
+	// LinkTechnology is an enumeration of the types of links.
+	LinkTechnology int
+	// PortType is the specific mode that is currently enabled on the Port.
+	PortType int
+)

--- a/pkg/wsman/cim/messages.go
+++ b/pkg/wsman/cim/messages.go
@@ -16,12 +16,14 @@ import (
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/computer"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/concrete"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/credential"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/ethernetport"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/ieee8021x"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/kvm"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/mediaaccess"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/physical"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/power"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/processor"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/redirectionservice"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/service"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/software"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/system"
@@ -31,29 +33,36 @@ import (
 )
 
 type Messages struct {
-	wsmanMessageCreator       *message.WSManMessageCreator
-	BIOSElement               bios.Element
-	BootConfigSetting         boot.ConfigSetting
-	BootService               boot.Service
-	BootSourceSetting         boot.SourceSetting
-	Card                      card.Package
-	Chassis                   chassis.Package
-	Chip                      chip.Package
-	ComputerSystemPackage     computer.SystemPackage
-	ConcreteDependency        concrete.Dependency
-	CredentialContext         credential.Context
-	IEEE8021xSettings         ieee8021x.Settings
-	KVMRedirectionSAP         kvm.RedirectionSAP
-	MediaAccessDevice         mediaaccess.Device
-	PhysicalMemory            physical.Memory
-	PhysicalPackage           physical.Package
-	PowerManagementService    power.ManagementService
-	Processor                 processor.Package
-	ServiceAvailableToElement service.AvailableToElement
-	SoftwareIdentity          software.Identity
-	SystemPackaging           system.Package
-	WiFiEndpointSettings      wifi.EndpointSettings
-	WiFiPort                  wifi.Port
+	wsmanMessageCreator         *message.WSManMessageCreator
+	BIOSElement                 bios.Element
+	BIOSFeature                 bios.Feature
+	BootConfigSetting           boot.ConfigSetting
+	BootService                 boot.Service
+	BootSourceSetting           boot.SourceSetting
+	Card                        card.Package
+	Chassis                     chassis.Package
+	Chip                        chip.Package
+	ComputerSystemPackage       computer.SystemPackage
+	ConcreteDependency          concrete.Dependency
+	CredentialContext           credential.Context
+	EthernetPort                ethernetport.Port
+	IEEE8021xSettings           ieee8021x.Settings
+	KVMRedirectionSAP           kvm.RedirectionSAP
+	MediaAccessDevice           mediaaccess.Device
+	PhysicalMemory              physical.Memory
+	PhysicalPackage             physical.Package
+	PowerManagementCapabilities power.Capabilities
+	PowerManagementService      power.ManagementService
+	Processor                   processor.Package
+	RedirectionService          redirectionservice.Service
+	ServiceAvailableToElement   service.AvailableToElement
+	SoftwareIdentity            software.Identity
+	SystemPackaging             system.Package
+	WiFiEndpoint                wifi.Endpoint
+	WiFiEndpointCapabilities    wifi.EndpointCapabilities
+	WiFiEndpointSettings        wifi.EndpointSettings
+	WiFiPort                    wifi.Port
+	WiFiPortCapabilities        wifi.PortCapabilities
 }
 
 func NewMessages(client client.WSMan) Messages {
@@ -63,6 +72,7 @@ func NewMessages(client client.WSMan) Messages {
 		wsmanMessageCreator: wsmanMessageCreator,
 	}
 	m.BIOSElement = bios.NewBIOSElementWithClient(wsmanMessageCreator, client)
+	m.BIOSFeature = bios.NewBIOSFeatureWithClient(wsmanMessageCreator, client)
 	m.BootConfigSetting = boot.NewBootConfigSettingWithClient(wsmanMessageCreator, client)
 	m.BootService = boot.NewBootServiceWithClient(wsmanMessageCreator, client)
 	m.BootSourceSetting = boot.NewBootSourceSettingWithClient(wsmanMessageCreator, client)
@@ -72,18 +82,24 @@ func NewMessages(client client.WSMan) Messages {
 	m.ComputerSystemPackage = computer.NewComputerSystemPackageWithClient(wsmanMessageCreator, client)
 	m.ConcreteDependency = concrete.NewDependencyWithClient(wsmanMessageCreator, client)
 	m.CredentialContext = credential.NewContextWithClient(wsmanMessageCreator, client)
+	m.EthernetPort = ethernetport.NewEthernetPortWithClient(wsmanMessageCreator, client)
 	m.IEEE8021xSettings = ieee8021x.NewIEEE8021xSettingsWithClient(wsmanMessageCreator, client)
 	m.KVMRedirectionSAP = kvm.NewKVMRedirectionSAPWithClient(wsmanMessageCreator, client)
 	m.MediaAccessDevice = mediaaccess.NewMediaAccessDeviceWithClient(wsmanMessageCreator, client)
 	m.PhysicalMemory = physical.NewPhysicalMemoryWithClient(wsmanMessageCreator, client)
 	m.PhysicalPackage = physical.NewPhysicalPackageWithClient(wsmanMessageCreator, client)
+	m.PowerManagementCapabilities = power.NewPowerManagementCapabilitiesWithClient(wsmanMessageCreator, client)
 	m.PowerManagementService = power.NewPowerManagementServiceWithClient(wsmanMessageCreator, client)
 	m.Processor = processor.NewProcessorWithClient(wsmanMessageCreator, client)
+	m.RedirectionService = redirectionservice.NewRedirectionServiceWithClient(wsmanMessageCreator, client)
 	m.ServiceAvailableToElement = service.NewServiceAvailableToElementWithClient(wsmanMessageCreator, client)
 	m.SoftwareIdentity = software.NewSoftwareIdentityWithClient(wsmanMessageCreator, client)
 	m.SystemPackaging = system.NewSystemPackageWithClient(wsmanMessageCreator, client)
+	m.WiFiEndpoint = wifi.NewWiFiEndpointWithClient(wsmanMessageCreator, client)
+	m.WiFiEndpointCapabilities = wifi.NewWiFiEndpointCapabilitiesWithClient(wsmanMessageCreator, client)
 	m.WiFiEndpointSettings = wifi.NewWiFiEndpointSettingsWithClient(wsmanMessageCreator, client)
 	m.WiFiPort = wifi.NewWiFiPortWithClient(wsmanMessageCreator, client)
+	m.WiFiPortCapabilities = wifi.NewWiFiPortCapabilitiesWithClient(wsmanMessageCreator, client)
 
 	return m
 }

--- a/pkg/wsman/cim/messages_test.go
+++ b/pkg/wsman/cim/messages_test.go
@@ -17,11 +17,13 @@ import (
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/computer"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/concrete"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/credential"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/ethernetport"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/kvm"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/mediaaccess"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/physical"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/power"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/processor"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/redirectionservice"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/service"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/software"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/system"
@@ -40,6 +42,10 @@ func TestNewMessages(t *testing.T) {
 
 	if reflect.DeepEqual(m.BIOSElement, bios.Element{}) {
 		t.Error("BIOSElement is not initialized")
+	}
+
+	if reflect.DeepEqual(m.BIOSFeature, bios.Feature{}) {
+		t.Error("BIOSFeature is not initialized")
 	}
 
 	if reflect.DeepEqual(m.BootConfigSetting, boot.ConfigSetting{}) {
@@ -78,6 +84,10 @@ func TestNewMessages(t *testing.T) {
 		t.Error("Context is not initialized")
 	}
 
+	if reflect.DeepEqual(m.EthernetPort, ethernetport.Port{}) {
+		t.Error("EthernetPort is not initialized")
+	}
+
 	if reflect.DeepEqual(m.IEEE8021xSettings, ieee8021x.IEEE8021xSettingsRequest{}) {
 		t.Error("IEEE8021xSettings is not initialized")
 	}
@@ -98,12 +108,20 @@ func TestNewMessages(t *testing.T) {
 		t.Error("PhysicalPackage is not initialized")
 	}
 
+	if reflect.DeepEqual(m.PowerManagementCapabilities, power.Capabilities{}) {
+		t.Error("PowerManagementCapabilities is not initialized")
+	}
+
 	if reflect.DeepEqual(m.PowerManagementService, power.ManagementService{}) {
 		t.Error("PowerManagementService is not initialized")
 	}
 
 	if reflect.DeepEqual(m.Processor, processor.Package{}) {
 		t.Error("Processor is not initialized")
+	}
+
+	if reflect.DeepEqual(m.RedirectionService, redirectionservice.Service{}) {
+		t.Error("RedirectionService is not initialized")
 	}
 
 	if reflect.DeepEqual(m.ServiceAvailableToElement, service.AvailableToElement{}) {
@@ -118,11 +136,23 @@ func TestNewMessages(t *testing.T) {
 		t.Error("SystemPackaging is not initialized")
 	}
 
+	if reflect.DeepEqual(m.WiFiEndpoint, wifi.Endpoint{}) {
+		t.Error("WiFiEndpoint is not initialized")
+	}
+
+	if reflect.DeepEqual(m.WiFiEndpointCapabilities, wifi.EndpointCapabilities{}) {
+		t.Error("WiFiEndpointCapabilities is not initialized")
+	}
+
 	if reflect.DeepEqual(m.WiFiEndpointSettings, wifi.EndpointSettings{}) {
 		t.Error("WiFiEndpointSettings is not initialized")
 	}
 
 	if reflect.DeepEqual(m.WiFiPort, wifi.Port{}) {
 		t.Error("WiFiPort is not initialized")
+	}
+
+	if reflect.DeepEqual(m.WiFiPortCapabilities, wifi.PortCapabilities{}) {
+		t.Error("WiFiPortCapabilities is not initialized")
 	}
 }

--- a/pkg/wsman/cim/power/capabilities.go
+++ b/pkg/wsman/cim/power/capabilities.go
@@ -1,0 +1,23 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package power
+
+import (
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/base"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+)
+
+type Capabilities struct {
+	base.WSManService[Response]
+}
+
+// NewPowerManagementCapabilitiesWithClient instantiates a new Capabilities service.
+func NewPowerManagementCapabilitiesWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) Capabilities {
+	return Capabilities{
+		base.NewService[Response](wsmanMessageCreator, CIMPowerManagementCapabilities, client),
+	}
+}

--- a/pkg/wsman/cim/power/capabilities_test.go
+++ b/pkg/wsman/cim/power/capabilities_test.go
@@ -1,0 +1,165 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package power
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+func TestPositiveCIMPowerManagementCapabilities(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/power/capabilities",
+	}
+	elementUnderTest := NewPowerManagementCapabilitiesWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_PowerManagementCapabilities Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"should create and parse a valid CIM_PowerManagementCapabilities Get call",
+				CIMPowerManagementCapabilities,
+				wsmantesting.Get,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageGet
+
+					return elementUnderTest.Get()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PowerManagementCapabilitiesGetResponse: PowerManagementCapabilities{
+						XMLName:                       xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_PowerManagementCapabilities", Local: CIMPowerManagementCapabilities},
+						ElementName:                   "Power Management Capabilities",
+						InstanceID:                    "Intel(r) AMT:PowerManagementCapabilities 0",
+						PowerChangeCapabilities:       []int{2, 3, 4, 7, 8},
+						PowerStatesSupported:          []int{5, 8, 2, 10, 11, 12, 14},
+						RequestedPowerStatesSupported: []int{5, 8, 2, 10, 11, 12, 14},
+					},
+				},
+			},
+			{
+				"should create a valid CIM_PowerManagementCapabilities Enumerate call",
+				CIMPowerManagementCapabilities,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{
+						EnumerationContext: "2F000000-0000-0000-0000-000000000000",
+					},
+				},
+			},
+			{
+				"should create a valid CIM_PowerManagementCapabilities Pull call",
+				CIMPowerManagementCapabilities,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: "http://schemas.xmlsoap.org/ws/2004/09/enumeration", Local: "PullResponse"},
+						PowerManagementCapabilitiesItems: []PowerManagementCapabilities{
+							{
+								XMLName:                       xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_PowerManagementCapabilities", Local: CIMPowerManagementCapabilities},
+								ElementName:                   "Power Management Capabilities",
+								InstanceID:                    "Intel(r) AMT:PowerManagementCapabilities 0",
+								PowerChangeCapabilities:       []int{2, 3, 4, 7, 8},
+								PowerStatesSupported:          []int{5, 8, 2, 10, 11, 12, 14},
+								RequestedPowerStatesSupported: []int{5, 8, 2, 10, 11, 12, 14},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, "", test.body)
+				messageID++
+				response, err := test.responseFunc()
+
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}
+
+func TestNegativeCIMPowerManagementCapabilities(t *testing.T) {
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/power/capabilities",
+	}
+	elementUnderTest := NewPowerManagementCapabilitiesWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_PowerManagementCapabilities Error Handling Tests", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			responseFunc func() (Response, error)
+		}{
+			{
+				"should handle error when Get fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Get()
+				},
+			},
+			{
+				"should handle error when Enumerate fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Enumerate()
+				},
+			},
+			{
+				"should handle error when Pull fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := test.responseFunc()
+				assert.Error(t, err)
+			})
+		}
+	})
+}

--- a/pkg/wsman/cim/power/decoder.go
+++ b/pkg/wsman/cim/power/decoder.go
@@ -6,9 +6,10 @@
 package power
 
 const (
-	CIMPowerManagementService string = "CIM_PowerManagementService"
-	RequestPowerStateChange   string = "RequestPowerStateChange"
-	ValueNotFound             string = "Value not found in map"
+	CIMPowerManagementService      string = "CIM_PowerManagementService"
+	CIMPowerManagementCapabilities string = "CIM_PowerManagementCapabilities"
+	RequestPowerStateChange        string = "RequestPowerStateChange"
+	ValueNotFound                  string = "Value not found in map"
 )
 
 // TODO: This list of contants needs to be scrubbed.

--- a/pkg/wsman/cim/power/managementservice_test.go
+++ b/pkg/wsman/cim/power/managementservice_test.go
@@ -27,7 +27,7 @@ func TestJson(t *testing.T) {
 			PullResponse: PullResponse{},
 		},
 	}
-	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"RequestPowerStateChangeResponse\":{\"ReturnValue\":0},\"GetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"CreationClassName\":\"\",\"ElementName\":\"\",\"EnabledState\":0,\"Name\":\"\",\"RequestedState\":0,\"SystemCreationClassName\":\"\",\"SystemName\":\"\"},\"EnumerateResponse\":{\"EnumerationContext\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"PowerManagementServiceItems\":null}}"
+	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"RequestPowerStateChangeResponse\":{\"ReturnValue\":0},\"GetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"CreationClassName\":\"\",\"ElementName\":\"\",\"EnabledState\":0,\"Name\":\"\",\"RequestedState\":0,\"SystemCreationClassName\":\"\",\"SystemName\":\"\"},\"PowerManagementCapabilitiesGetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"InstanceID\":\"\",\"ElementName\":\"\",\"PowerChangeCapabilities\":null,\"OtherPowerChangeCapabilities\":\"\",\"PowerStatesSupported\":null,\"RequestedPowerStatesSupported\":null},\"EnumerateResponse\":{\"EnumerationContext\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"PowerManagementServiceItems\":null,\"PowerManagementCapabilitiesItems\":null}}"
 	result := response.JSON()
 	assert.Equal(t, expectedResult, result)
 }
@@ -38,7 +38,7 @@ func TestYaml(t *testing.T) {
 			PullResponse: PullResponse{},
 		},
 	}
-	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\nrequestpowerstatechangeresponse:\n    returnvalue: 0\ngetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    creationclassname: \"\"\n    elementname: \"\"\n    enabledstate: 0\n    name: \"\"\n    requestedstate: 0\n    systemcreationclassname: \"\"\n    systemname: \"\"\nenumerateresponse:\n    enumerationcontext: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    powermanagementserviceitems: []\n"
+	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\nrequestpowerstatechangeresponse:\n    returnvalue: 0\ngetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    creationclassname: \"\"\n    elementname: \"\"\n    enabledstate: 0\n    name: \"\"\n    requestedstate: 0\n    systemcreationclassname: \"\"\n    systemname: \"\"\npowermanagementcapabilitiesgetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    instanceid: \"\"\n    elementname: \"\"\n    powerchangecapabilities: []\n    otherpowerchangecapabilities: \"\"\n    powerstatessupported: []\n    requestedpowerstatessupported: []\nenumerateresponse:\n    enumerationcontext: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    powermanagementserviceitems: []\n    powermanagementcapabilitiesitems: []\n"
 	result := response.YAML()
 	assert.Equal(t, expectedResult, result)
 }

--- a/pkg/wsman/cim/power/types.go
+++ b/pkg/wsman/cim/power/types.go
@@ -24,16 +24,28 @@ type (
 		Body    Body           `xml:"Body"`
 	}
 	Body struct {
-		XMLName                         xml.Name            `xml:"Body"`
-		RequestPowerStateChangeResponse PowerActionResponse `xml:"RequestPowerStateChange_OUTPUT"`
-		GetResponse                     PowerManagementService
-		EnumerateResponse               common.EnumerateResponse
-		PullResponse                    PullResponse
+		XMLName                                xml.Name            `xml:"Body"`
+		RequestPowerStateChangeResponse        PowerActionResponse `xml:"RequestPowerStateChange_OUTPUT"`
+		GetResponse                            PowerManagementService
+		PowerManagementCapabilitiesGetResponse PowerManagementCapabilities `xml:"CIM_PowerManagementCapabilities"`
+		EnumerateResponse                      common.EnumerateResponse
+		PullResponse                           PullResponse
 	}
 
 	PullResponse struct {
-		XMLName                     xml.Name                 `xml:"PullResponse"`
-		PowerManagementServiceItems []PowerManagementService `xml:"Items>CIM_PowerManagementService"`
+		XMLName                          xml.Name                      `xml:"PullResponse"`
+		PowerManagementServiceItems      []PowerManagementService      `xml:"Items>CIM_PowerManagementService"`
+		PowerManagementCapabilitiesItems []PowerManagementCapabilities `xml:"Items>CIM_PowerManagementCapabilities"`
+	}
+
+	PowerManagementCapabilities struct {
+		XMLName                       xml.Name `xml:"CIM_PowerManagementCapabilities"`
+		InstanceID                    string   `xml:"InstanceID"`
+		ElementName                   string   `xml:"ElementName"`
+		PowerChangeCapabilities       []int    `xml:"PowerChangeCapabilities,omitempty"`
+		OtherPowerChangeCapabilities  string   `xml:"OtherPowerChangeCapabilities,omitempty"`
+		PowerStatesSupported          []int    `xml:"PowerStatesSupported,omitempty"`
+		RequestedPowerStatesSupported []int    `xml:"RequestedPowerStatesSupported,omitempty"`
 	}
 
 	PowerManagementService struct {

--- a/pkg/wsman/cim/redirectionservice/decoder.go
+++ b/pkg/wsman/cim/redirectionservice/decoder.go
@@ -1,0 +1,11 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package redirectionservice
+
+const (
+	CIMRedirectionService string = "CIM_RedirectionService"
+	ValueNotFound         string = "Value not found in map"
+)

--- a/pkg/wsman/cim/redirectionservice/marshal.go
+++ b/pkg/wsman/cim/redirectionservice/marshal.go
@@ -1,0 +1,32 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package redirectionservice
+
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+// JSON marshals the type into JSON format.
+func (r *Response) JSON() string {
+	jsonOutput, err := json.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(jsonOutput)
+}
+
+// YAML marshals the type into YAML format.
+func (r *Response) YAML() string {
+	yamlOutput, err := yaml.Marshal(r.Body)
+	if err != nil {
+		return ""
+	}
+
+	return string(yamlOutput)
+}

--- a/pkg/wsman/cim/redirectionservice/service.go
+++ b/pkg/wsman/cim/redirectionservice/service.go
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package redirectionservice facilitates communication with Intel® AMT devices to access CIM_RedirectionService data.
+package redirectionservice
+
+import (
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/base"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+)
+
+type Service struct {
+	base.WSManService[Response]
+}
+
+// NewRedirectionServiceWithClient instantiates a new RedirectionService.
+func NewRedirectionServiceWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) Service {
+	return Service{
+		base.NewService[Response](wsmanMessageCreator, CIMRedirectionService, client),
+	}
+}

--- a/pkg/wsman/cim/redirectionservice/service_test.go
+++ b/pkg/wsman/cim/redirectionservice/service_test.go
@@ -1,0 +1,175 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package redirectionservice
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+func TestPositiveCIMRedirectionService(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/redirectionservice",
+	}
+	elementUnderTest := NewRedirectionServiceWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_RedirectionService Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"should create and parse a valid CIM_RedirectionService Get call",
+				CIMRedirectionService,
+				wsmantesting.Get,
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageGet
+
+					return elementUnderTest.Get()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					GetResponse: RedirectionService{
+						XMLName:                 xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_RedirectionService", Local: CIMRedirectionService},
+						CreationClassName:       "CIM_RedirectionService",
+						ElementName:             "Intel(r) ME KVM Redirection Service",
+						EnabledState:            3,
+						Name:                    "Intel(r) AMT KVM Redirection Service",
+						RequestedState:          12,
+						SystemCreationClassName: "CIM_ComputerSystem",
+						SystemName:              "Intel(r) AMT",
+						MaxCurrentEnabledSAPs:   1,
+						RedirectionServiceType:  []int{3},
+						SharingMode:             3,
+					},
+				},
+			},
+			{
+				"should create a valid CIM_RedirectionService Enumerate call",
+				CIMRedirectionService,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{
+						EnumerationContext: "30000000-0000-0000-0000-000000000000",
+					},
+				},
+			},
+			{
+				"should create a valid CIM_RedirectionService Pull call",
+				CIMRedirectionService,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: "http://schemas.xmlsoap.org/ws/2004/09/enumeration", Local: "PullResponse"},
+						RedirectionServiceItems: []RedirectionService{
+							{
+								XMLName:                 xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_RedirectionService", Local: CIMRedirectionService},
+								CreationClassName:       "CIM_RedirectionService",
+								ElementName:             "Intel(r) ME KVM Redirection Service",
+								EnabledState:            3,
+								Name:                    "Intel(r) AMT KVM Redirection Service",
+								RequestedState:          12,
+								SystemCreationClassName: "CIM_ComputerSystem",
+								SystemName:              "Intel(r) AMT",
+								MaxCurrentEnabledSAPs:   1,
+								RedirectionServiceType:  []int{3},
+								SharingMode:             3,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, "", test.body)
+				messageID++
+				response, err := test.responseFunc()
+
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}
+
+func TestNegativeCIMRedirectionService(t *testing.T) {
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/redirectionservice",
+	}
+	elementUnderTest := NewRedirectionServiceWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_RedirectionService Error Handling Tests", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			responseFunc func() (Response, error)
+		}{
+			{
+				"should handle error when Get fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Get()
+				},
+			},
+			{
+				"should handle error when Enumerate fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Enumerate()
+				},
+			},
+			{
+				"should handle error when Pull fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := test.responseFunc()
+				assert.Error(t, err)
+			})
+		}
+	})
+}

--- a/pkg/wsman/cim/redirectionservice/types.go
+++ b/pkg/wsman/cim/redirectionservice/types.go
@@ -1,0 +1,56 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package redirectionservice
+
+import (
+	"encoding/xml"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+)
+
+// Response Types.
+type (
+	Response struct {
+		*client.Message
+		XMLName xml.Name       `xml:"Envelope"`
+		Header  message.Header `xml:"Header"`
+		Body    Body           `xml:"Body"`
+	}
+
+	Body struct {
+		XMLName           xml.Name `xml:"Body"`
+		GetResponse       RedirectionService
+		EnumerateResponse common.EnumerateResponse
+		PullResponse      PullResponse
+	}
+
+	RedirectionService struct {
+		XMLName                 xml.Name       `xml:"CIM_RedirectionService"`
+		CreationClassName       string         `xml:"CreationClassName,omitempty"`       // CreationClassName indicates the name of the class or the subclass used in the creation of an instance.
+		ElementName             string         `xml:"ElementName,omitempty"`             // A user-friendly name for the object.
+		EnabledState            EnabledState   `xml:"EnabledState,omitempty"`            // EnabledState is an integer enumeration that indicates the enabled and disabled states of an element.
+		Name                    string         `xml:"Name,omitempty"`                    // The Name property uniquely identifies the Service.
+		RequestedState          RequestedState `xml:"RequestedState,omitempty"`          // RequestedState is an integer enumeration that indicates the last requested or desired state for the element.
+		SystemCreationClassName string         `xml:"SystemCreationClassName,omitempty"` // The CreationClassName of the scoping System.
+		SystemName              string         `xml:"SystemName,omitempty"`              // The Name of the scoping System.
+		AccessLog               []string       `xml:"AccessLog,omitempty"`               // An array of free-form strings that provide information about the access.
+		MaxCurrentEnabledSAPs   int            `xml:"MaxCurrentEnabledSAPs,omitempty"`   // The maximum number of currently enabled SAPs supported by this service.
+		RedirectionServiceType  []int          `xml:"RedirectionServiceType,omitempty"`  // An enumeration indicating the type(s) of redirection supported by this service.
+		SharingMode             int            `xml:"SharingMode,omitempty"`             // An enumeration that indicates how the redirection service may be shared.
+	}
+
+	PullResponse struct {
+		XMLName                 xml.Name             `xml:"PullResponse"`
+		RedirectionServiceItems []RedirectionService `xml:"Items>CIM_RedirectionService"`
+	}
+
+	// EnabledState is an integer enumeration that indicates the enabled and disabled states of an element.
+	EnabledState int
+	// RequestedState is an integer enumeration that indicates the last requested or desired state for the element.
+	RequestedState int
+)

--- a/pkg/wsman/cim/wifi/decoder.go
+++ b/pkg/wsman/cim/wifi/decoder.go
@@ -8,10 +8,12 @@ package wifi
 import "strings"
 
 const (
-	CIMWiFiEndpoint         string = "CIM_WiFiEndpoint"
-	CIMWiFiEndpointSettings string = "CIM_WiFiEndpointSettings"
-	CIMWiFiPort             string = "CIM_WiFiPort"
-	ValueNotFound           string = "Value not found in map"
+	CIMWiFiEndpoint             string = "CIM_WiFiEndpoint"
+	CIMWiFiEndpointCapabilities string = "CIM_WiFiEndpointCapabilities"
+	CIMWiFiEndpointSettings     string = "CIM_WiFiEndpointSettings"
+	CIMWiFiPort                 string = "CIM_WiFiPort"
+	CIMWiFiPortCapabilities     string = "CIM_WiFiPortCapabilities"
+	ValueNotFound               string = "Value not found in map"
 )
 
 const (

--- a/pkg/wsman/cim/wifi/endpoint.go
+++ b/pkg/wsman/cim/wifi/endpoint.go
@@ -1,0 +1,23 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package wifi
+
+import (
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/base"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+)
+
+type Endpoint struct {
+	base.WSManService[Response]
+}
+
+// NewWiFiEndpointWithClient returns a new instance of the WiFiEndpoint struct.
+func NewWiFiEndpointWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) Endpoint {
+	return Endpoint{
+		base.NewService[Response](wsmanMessageCreator, CIMWiFiEndpoint, client),
+	}
+}

--- a/pkg/wsman/cim/wifi/endpoint_test.go
+++ b/pkg/wsman/cim/wifi/endpoint_test.go
@@ -1,0 +1,131 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package wifi
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+func TestPositiveCIMWiFiEndpoint(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/wifi/endpoint",
+	}
+	elementUnderTest := NewWiFiEndpointWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_WiFiEndpoint Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"should create a valid CIM_WiFiEndpoint Enumerate call",
+				CIMWiFiEndpoint,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{
+						EnumerationContext: "C4020000-0000-0000-0000-000000000000",
+					},
+				},
+			},
+			{
+				"should create a valid CIM_WiFiEndpoint Pull call",
+				CIMWiFiEndpoint,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: "http://schemas.xmlsoap.org/ws/2004/09/enumeration", Local: "PullResponse"},
+						WiFiEndpointItems: []WiFiEndpoint{
+							{
+								XMLName:     xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpoint", Local: CIMWiFiEndpoint},
+								ElementName: "CIM_WiFiEndpoint",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, "", test.body)
+				messageID++
+				response, err := test.responseFunc()
+
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}
+
+func TestNegativeCIMWiFiEndpoint(t *testing.T) {
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/wifi/endpoint",
+	}
+	elementUnderTest := NewWiFiEndpointWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_WiFiEndpoint Error Handling Tests", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			responseFunc func() (Response, error)
+		}{
+			{
+				"should handle error when Enumerate fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Enumerate()
+				},
+			},
+			{
+				"should handle error when Pull fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := test.responseFunc()
+				assert.Error(t, err)
+			})
+		}
+	})
+}

--- a/pkg/wsman/cim/wifi/endpointcapabilities.go
+++ b/pkg/wsman/cim/wifi/endpointcapabilities.go
@@ -1,0 +1,23 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package wifi
+
+import (
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/base"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+)
+
+type EndpointCapabilities struct {
+	base.WSManService[Response]
+}
+
+// NewWiFiEndpointCapabilitiesWithClient returns a new instance of the EndpointCapabilities struct.
+func NewWiFiEndpointCapabilitiesWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) EndpointCapabilities {
+	return EndpointCapabilities{
+		base.NewService[Response](wsmanMessageCreator, CIMWiFiEndpointCapabilities, client),
+	}
+}

--- a/pkg/wsman/cim/wifi/endpointcapabilities_test.go
+++ b/pkg/wsman/cim/wifi/endpointcapabilities_test.go
@@ -1,0 +1,131 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package wifi
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+func TestPositiveCIMWiFiEndpointCapabilities(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/wifi/endpointcapabilities",
+	}
+	elementUnderTest := NewWiFiEndpointCapabilitiesWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_WiFiEndpointCapabilities Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"should create a valid CIM_WiFiEndpointCapabilities Enumerate call",
+				CIMWiFiEndpointCapabilities,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{
+						EnumerationContext: "C4020000-0000-0000-0000-000000000000",
+					},
+				},
+			},
+			{
+				"should create a valid CIM_WiFiEndpointCapabilities Pull call",
+				CIMWiFiEndpointCapabilities,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: "http://schemas.xmlsoap.org/ws/2004/09/enumeration", Local: "PullResponse"},
+						WiFiEndpointCapabilitiesItems: []WiFiEndpointCapabilities{
+							{
+								XMLName:     xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpointCapabilities", Local: CIMWiFiEndpointCapabilities},
+								ElementName: "CIM_WiFiEndpointCapabilities",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, "", test.body)
+				messageID++
+				response, err := test.responseFunc()
+
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}
+
+func TestNegativeCIMWiFiEndpointCapabilities(t *testing.T) {
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/wifi/endpointcapabilities",
+	}
+	elementUnderTest := NewWiFiEndpointCapabilitiesWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_WiFiEndpointCapabilities Error Handling Tests", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			responseFunc func() (Response, error)
+		}{
+			{
+				"should handle error when Enumerate fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Enumerate()
+				},
+			},
+			{
+				"should handle error when Pull fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := test.responseFunc()
+				assert.Error(t, err)
+			})
+		}
+	})
+}

--- a/pkg/wsman/cim/wifi/endpointsettings_test.go
+++ b/pkg/wsman/cim/wifi/endpointsettings_test.go
@@ -22,7 +22,7 @@ func TestJson(t *testing.T) {
 			PullResponse: PullResponse{},
 		},
 	}
-	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"WiFiPortGetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"LinkTechnology\":0,\"DeviceID\":\"\",\"CreationClassName\":\"\",\"SystemName\":\"\",\"SystemCreationClassName\":\"\",\"ElementName\":\"\",\"HealthState\":0,\"EnabledState\":0,\"RequestedState\":0,\"PortType\":0,\"PermanentAddress\":\"\"},\"EnumerateResponse\":{\"EnumerationContext\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"EndpointSettingsItems\":null,\"WiFiPortItems\":null},\"RequestStateChange_OUTPUT\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"ReturnValue\":0,\"ReturnValueStr\":\"\"}}"
+	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"WiFiPortGetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"LinkTechnology\":0,\"DeviceID\":\"\",\"CreationClassName\":\"\",\"SystemName\":\"\",\"SystemCreationClassName\":\"\",\"ElementName\":\"\",\"HealthState\":0,\"EnabledState\":0,\"RequestedState\":0,\"PortType\":0,\"PermanentAddress\":\"\"},\"EnumerateResponse\":{\"EnumerationContext\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"WiFiEndpointItems\":null,\"WiFiEndpointCapabilitiesItems\":null,\"WiFiPortCapabilitiesItems\":null,\"EndpointSettingsItems\":null,\"WiFiPortItems\":null},\"RequestStateChange_OUTPUT\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"ReturnValue\":0,\"ReturnValueStr\":\"\"}}"
 	result := response.JSON()
 	assert.Equal(t, expectedResult, result)
 }
@@ -33,7 +33,7 @@ func TestYaml(t *testing.T) {
 			PullResponse: PullResponse{},
 		},
 	}
-	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\nwifiportgetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    linktechnology: 0\n    deviceid: \"\"\n    creationclassname: \"\"\n    systemname: \"\"\n    systemcreationclassname: \"\"\n    elementname: \"\"\n    healthstate: 0\n    enabledstate: 0\n    requestedstate: 0\n    porttype: 0\n    permanentaddress: \"\"\nenumerateresponse:\n    enumerationcontext: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    endpointsettingsitems: []\n    wifiportitems: []\nrequeststatechange_output:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    returnvalue: 0\n    returnvaluestr: \"\"\n"
+	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\nwifiportgetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    linktechnology: 0\n    deviceid: \"\"\n    creationclassname: \"\"\n    systemname: \"\"\n    systemcreationclassname: \"\"\n    elementname: \"\"\n    healthstate: 0\n    enabledstate: 0\n    requestedstate: 0\n    porttype: 0\n    permanentaddress: \"\"\nenumerateresponse:\n    enumerationcontext: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    wifiendpointitems: []\n    wifiendpointcapabilitiesitems: []\n    wifiportcapabilitiesitems: []\n    endpointsettingsitems: []\n    wifiportitems: []\nrequeststatechange_output:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    returnvalue: 0\n    returnvaluestr: \"\"\n"
 	result := response.YAML()
 	assert.Equal(t, expectedResult, result)
 }

--- a/pkg/wsman/cim/wifi/portcapabilities.go
+++ b/pkg/wsman/cim/wifi/portcapabilities.go
@@ -1,0 +1,23 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package wifi
+
+import (
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/base"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+)
+
+type PortCapabilities struct {
+	base.WSManService[Response]
+}
+
+// NewWiFiPortCapabilitiesWithClient returns a new instance of the PortCapabilities struct.
+func NewWiFiPortCapabilitiesWithClient(wsmanMessageCreator *message.WSManMessageCreator, client client.WSMan) PortCapabilities {
+	return PortCapabilities{
+		base.NewService[Response](wsmanMessageCreator, CIMWiFiPortCapabilities, client),
+	}
+}

--- a/pkg/wsman/cim/wifi/portcapabilities_test.go
+++ b/pkg/wsman/cim/wifi/portcapabilities_test.go
@@ -1,0 +1,131 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package wifi
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
+)
+
+func TestPositiveCIMWiFiPortCapabilities(t *testing.T) {
+	messageID := 0
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/wifi/portcapabilities",
+	}
+	elementUnderTest := NewWiFiPortCapabilitiesWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_WiFiPortCapabilities Tests", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			method           string
+			action           string
+			body             string
+			responseFunc     func() (Response, error)
+			expectedResponse interface{}
+		}{
+			{
+				"should create a valid CIM_WiFiPortCapabilities Enumerate call",
+				CIMWiFiPortCapabilities,
+				wsmantesting.Enumerate,
+				wsmantesting.EnumerateBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageEnumerate
+
+					return elementUnderTest.Enumerate()
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					EnumerateResponse: common.EnumerateResponse{
+						EnumerationContext: "C4020000-0000-0000-0000-000000000000",
+					},
+				},
+			},
+			{
+				"should create a valid CIM_WiFiPortCapabilities Pull call",
+				CIMWiFiPortCapabilities,
+				wsmantesting.Pull,
+				wsmantesting.PullBody,
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessagePull
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					PullResponse: PullResponse{
+						XMLName: xml.Name{Space: "http://schemas.xmlsoap.org/ws/2004/09/enumeration", Local: "PullResponse"},
+						WiFiPortCapabilitiesItems: []WiFiPortCapabilities{
+							{
+								XMLName:     xml.Name{Space: "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiPortCapabilities", Local: CIMWiFiPortCapabilities},
+								ElementName: "CIM_WiFiPortCapabilities",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				expectedXMLInput := wsmantesting.ExpectedResponse(messageID, resourceURIBase, test.method, test.action, "", test.body)
+				messageID++
+				response, err := test.responseFunc()
+
+				assert.NoError(t, err)
+				assert.Equal(t, expectedXMLInput, response.XMLInput)
+				assert.Equal(t, test.expectedResponse, response.Body)
+			})
+		}
+	})
+}
+
+func TestNegativeCIMWiFiPortCapabilities(t *testing.T) {
+	resourceURIBase := wsmantesting.CIMResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "cim/wifi/portcapabilities",
+	}
+	elementUnderTest := NewWiFiPortCapabilitiesWithClient(wsmanMessageCreator, &client)
+
+	t.Run("cim_WiFiPortCapabilities Error Handling Tests", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			responseFunc func() (Response, error)
+		}{
+			{
+				"should handle error when Enumerate fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Enumerate()
+				},
+			},
+			{
+				"should handle error when Pull fails",
+				func() (Response, error) {
+					client.CurrentMessage = wsmantesting.CurrentMessageError
+
+					return elementUnderTest.Pull(wsmantesting.EnumerationContext)
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := test.responseFunc()
+				assert.Error(t, err)
+			})
+		}
+	})
+}

--- a/pkg/wsman/cim/wifi/types.go
+++ b/pkg/wsman/cim/wifi/types.go
@@ -32,9 +32,27 @@ type (
 	}
 
 	PullResponse struct {
-		XMLName               xml.Name                       `xml:"PullResponse"`
-		EndpointSettingsItems []WiFiEndpointSettingsResponse `xml:"Items>CIM_WiFiEndpointSettings"`
-		WiFiPortItems         []WiFiPort                     `xml:"Items>CIM_WiFiPort"`
+		XMLName                       xml.Name                       `xml:"PullResponse"`
+		WiFiEndpointItems             []WiFiEndpoint                 `xml:"Items>CIM_WiFiEndpoint"`
+		WiFiEndpointCapabilitiesItems []WiFiEndpointCapabilities     `xml:"Items>CIM_WiFiEndpointCapabilities"`
+		WiFiPortCapabilitiesItems     []WiFiPortCapabilities         `xml:"Items>CIM_WiFiPortCapabilities"`
+		EndpointSettingsItems         []WiFiEndpointSettingsResponse `xml:"Items>CIM_WiFiEndpointSettings"`
+		WiFiPortItems                 []WiFiPort                     `xml:"Items>CIM_WiFiPort"`
+	}
+
+	WiFiEndpoint struct {
+		XMLName     xml.Name `xml:"CIM_WiFiEndpoint"`
+		ElementName string   `xml:"ElementName"`
+	}
+
+	WiFiEndpointCapabilities struct {
+		XMLName     xml.Name `xml:"CIM_WiFiEndpointCapabilities"`
+		ElementName string   `xml:"ElementName"`
+	}
+
+	WiFiPortCapabilities struct {
+		XMLName     xml.Name `xml:"CIM_WiFiPortCapabilities"`
+		ElementName string   `xml:"ElementName"`
 	}
 
 	WiFiEndpointSettingsResponse struct {

--- a/pkg/wsman/wsmantesting/responses/cim/bios/feature/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/bios/feature/enumerate.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <a:Header>
+    <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+    <b:RelatesTo>0</b:RelatesTo>
+    <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+    <b:MessageID>uuid:00000000-8086-8086-8086-0000000000BA</b:MessageID>
+    <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BIOSFeature</c:ResourceURI>
+  </a:Header>
+  <a:Body>
+    <g:EnumerateResponse>
+      <g:EnumerationContext>2D000000-0000-0000-0000-000000000000</g:EnumerationContext>
+    </g:EnumerateResponse>
+  </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/bios/feature/get.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/bios/feature/get.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BIOSFeature" xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <a:Header>
+    <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+    <b:RelatesTo>2</b:RelatesTo>
+    <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</b:Action>
+    <b:MessageID>uuid:00000000-8086-8086-8086-0000000000BC</b:MessageID>
+    <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BIOSFeature</c:ResourceURI>
+  </a:Header>
+  <a:Body>
+    <g:CIM_BIOSFeature>
+      <g:Characteristics>7</g:Characteristics>
+      <g:Characteristics>11</g:Characteristics>
+      <g:Characteristics>12</g:Characteristics>
+      <g:Characteristics>27</g:Characteristics>
+      <g:Characteristics>28</g:Characteristics>
+      <g:Characteristics>29</g:Characteristics>
+      <g:Characteristics>31</g:Characteristics>
+      <g:ElementName>Primary BIOS Features</g:ElementName>
+      <g:IdentifyingNumber>M46580-303</g:IdentifyingNumber>
+      <g:Name>Primary BIOS Features</g:Name>
+      <g:OperationalStatus>0</g:OperationalStatus>
+      <g:ProductName>NUC12WSHv5</g:ProductName>
+      <g:Vendor>Intel(R) Client Systems</g:Vendor>
+      <g:Version>M46580-303</g:Version>
+    </g:CIM_BIOSFeature>
+  </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/bios/feature/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/bios/feature/pull.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BIOSFeature" xmlns:i="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <a:Header>
+    <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+    <b:RelatesTo>1</b:RelatesTo>
+    <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+    <b:MessageID>uuid:00000000-8086-8086-8086-0000000000BB</b:MessageID>
+    <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BIOSFeature</c:ResourceURI>
+  </a:Header>
+  <a:Body>
+    <g:PullResponse>
+      <g:Items>
+        <h:CIM_BIOSFeature>
+          <h:Characteristics>7</h:Characteristics>
+          <h:Characteristics>11</h:Characteristics>
+          <h:Characteristics>12</h:Characteristics>
+          <h:Characteristics>27</h:Characteristics>
+          <h:Characteristics>28</h:Characteristics>
+          <h:Characteristics>29</h:Characteristics>
+          <h:Characteristics>31</h:Characteristics>
+          <h:ElementName>Primary BIOS Features</h:ElementName>
+          <h:IdentifyingNumber>M46580-303</h:IdentifyingNumber>
+          <h:Name>Primary BIOS Features</h:Name>
+          <h:OperationalStatus>0</h:OperationalStatus>
+          <h:ProductName>NUC12WSHv5</h:ProductName>
+          <h:Vendor>Intel(R) Client Systems</h:Vendor>
+          <h:Version>M46580-303</h:Version>
+        </h:CIM_BIOSFeature>
+      </g:Items>
+      <g:EndOfSequence/>
+    </g:PullResponse>
+  </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/ethernetport/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/ethernetport/enumerate.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <a:Header>
+    <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+    <b:RelatesTo>0</b:RelatesTo>
+    <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+    <b:MessageID>uuid:00000000-8086-8086-8086-0000000000BD</b:MessageID>
+    <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_EthernetPort</c:ResourceURI>
+  </a:Header>
+  <a:Body>
+    <g:EnumerateResponse>
+      <g:EnumerationContext>2E000000-0000-0000-0000-000000000000</g:EnumerationContext>
+    </g:EnumerateResponse>
+  </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/ethernetport/get.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/ethernetport/get.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_EthernetPort" xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <a:Header>
+    <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+    <b:RelatesTo>2</b:RelatesTo>
+    <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</b:Action>
+    <b:MessageID>uuid:00000000-8086-8086-8086-0000000000BF</b:MessageID>
+    <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_EthernetPort</c:ResourceURI>
+  </a:Header>
+  <a:Body>
+    <g:CIM_EthernetPort>
+      <g:CreationClassName>CIM_EthernetPort</g:CreationClassName>
+      <g:Description>Wired0</g:Description>
+      <g:DeviceID>Intel(r) AMT Ethernet Port 0</g:DeviceID>
+      <g:ElementName>Intel(r) AMT Ethernet Port</g:ElementName>
+      <g:EnabledDefault>5</g:EnabledDefault>
+      <g:EnabledState>2</g:EnabledState>
+      <g:LinkTechnology>2</g:LinkTechnology>
+      <g:MaxSpeed>2500000000</g:MaxSpeed>
+      <g:NetworkAddresses>48210b50d8c9</g:NetworkAddresses>
+      <g:OperationalStatus>0</g:OperationalStatus>
+      <g:PortType>53</g:PortType>
+      <g:RequestedState>12</g:RequestedState>
+      <g:Speed>1000000000</g:Speed>
+      <g:SystemCreationClassName>CIM_ComputerSystem</g:SystemCreationClassName>
+      <g:SystemName>Intel(r) AMT</g:SystemName>
+    </g:CIM_EthernetPort>
+  </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/ethernetport/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/ethernetport/pull.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_EthernetPort" xmlns:i="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <a:Header>
+    <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+    <b:RelatesTo>1</b:RelatesTo>
+    <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+    <b:MessageID>uuid:00000000-8086-8086-8086-0000000000BE</b:MessageID>
+    <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_EthernetPort</c:ResourceURI>
+  </a:Header>
+  <a:Body>
+    <g:PullResponse>
+      <g:Items>
+        <h:CIM_EthernetPort>
+          <h:CreationClassName>CIM_EthernetPort</h:CreationClassName>
+          <h:Description>Wired0</h:Description>
+          <h:DeviceID>Intel(r) AMT Ethernet Port 0</h:DeviceID>
+          <h:ElementName>Intel(r) AMT Ethernet Port</h:ElementName>
+          <h:EnabledDefault>5</h:EnabledDefault>
+          <h:EnabledState>2</h:EnabledState>
+          <h:LinkTechnology>2</h:LinkTechnology>
+          <h:MaxSpeed>2500000000</h:MaxSpeed>
+          <h:NetworkAddresses>48210b50d8c9</h:NetworkAddresses>
+          <h:OperationalStatus>0</h:OperationalStatus>
+          <h:PortType>53</h:PortType>
+          <h:RequestedState>12</h:RequestedState>
+          <h:Speed>1000000000</h:Speed>
+          <h:SystemCreationClassName>CIM_ComputerSystem</h:SystemCreationClassName>
+          <h:SystemName>Intel(r) AMT</h:SystemName>
+        </h:CIM_EthernetPort>
+      </g:Items>
+      <g:EndOfSequence/>
+    </g:PullResponse>
+  </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/power/capabilities/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/power/capabilities/enumerate.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <a:Header>
+    <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+    <b:RelatesTo>0</b:RelatesTo>
+    <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+    <b:MessageID>uuid:00000000-8086-8086-8086-0000000000C0</b:MessageID>
+    <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_PowerManagementCapabilities</c:ResourceURI>
+  </a:Header>
+  <a:Body>
+    <g:EnumerateResponse>
+      <g:EnumerationContext>2F000000-0000-0000-0000-000000000000</g:EnumerationContext>
+    </g:EnumerateResponse>
+  </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/power/capabilities/get.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/power/capabilities/get.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_PowerManagementCapabilities" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <a:Header>
+    <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+    <b:RelatesTo>2</b:RelatesTo>
+    <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</b:Action>
+    <b:MessageID>uuid:00000000-8086-8086-8086-0000000000C2</b:MessageID>
+    <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_PowerManagementCapabilities</c:ResourceURI>
+  </a:Header>
+  <a:Body>
+    <g:CIM_PowerManagementCapabilities>
+      <g:ElementName>Power Management Capabilities</g:ElementName>
+      <g:InstanceID>Intel(r) AMT:PowerManagementCapabilities 0</g:InstanceID>
+      <g:OtherPowerChangeCapabilities/>
+      <g:PowerChangeCapabilities>2</g:PowerChangeCapabilities>
+      <g:PowerChangeCapabilities>3</g:PowerChangeCapabilities>
+      <g:PowerChangeCapabilities>4</g:PowerChangeCapabilities>
+      <g:PowerChangeCapabilities>7</g:PowerChangeCapabilities>
+      <g:PowerChangeCapabilities>8</g:PowerChangeCapabilities>
+      <g:PowerStatesSupported>5</g:PowerStatesSupported>
+      <g:PowerStatesSupported>8</g:PowerStatesSupported>
+      <g:PowerStatesSupported>2</g:PowerStatesSupported>
+      <g:PowerStatesSupported>10</g:PowerStatesSupported>
+      <g:PowerStatesSupported>11</g:PowerStatesSupported>
+      <g:PowerStatesSupported>12</g:PowerStatesSupported>
+      <g:PowerStatesSupported>14</g:PowerStatesSupported>
+      <g:RequestedPowerStatesSupported>5</g:RequestedPowerStatesSupported>
+      <g:RequestedPowerStatesSupported>8</g:RequestedPowerStatesSupported>
+      <g:RequestedPowerStatesSupported>2</g:RequestedPowerStatesSupported>
+      <g:RequestedPowerStatesSupported>10</g:RequestedPowerStatesSupported>
+      <g:RequestedPowerStatesSupported>11</g:RequestedPowerStatesSupported>
+      <g:RequestedPowerStatesSupported>12</g:RequestedPowerStatesSupported>
+      <g:RequestedPowerStatesSupported>14</g:RequestedPowerStatesSupported>
+    </g:CIM_PowerManagementCapabilities>
+  </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/power/capabilities/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/power/capabilities/pull.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_PowerManagementCapabilities" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <a:Header>
+    <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+    <b:RelatesTo>1</b:RelatesTo>
+    <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+    <b:MessageID>uuid:00000000-8086-8086-8086-0000000000C1</b:MessageID>
+    <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_PowerManagementCapabilities</c:ResourceURI>
+  </a:Header>
+  <a:Body>
+    <g:PullResponse>
+      <g:EnumerationContext>2F000000-0000-0000-0000-000000000000</g:EnumerationContext>
+      <g:Items>
+        <h:CIM_PowerManagementCapabilities>
+          <h:ElementName>Power Management Capabilities</h:ElementName>
+          <h:InstanceID>Intel(r) AMT:PowerManagementCapabilities 0</h:InstanceID>
+          <h:OtherPowerChangeCapabilities/>
+          <h:PowerChangeCapabilities>2</h:PowerChangeCapabilities>
+          <h:PowerChangeCapabilities>3</h:PowerChangeCapabilities>
+          <h:PowerChangeCapabilities>4</h:PowerChangeCapabilities>
+          <h:PowerChangeCapabilities>7</h:PowerChangeCapabilities>
+          <h:PowerChangeCapabilities>8</h:PowerChangeCapabilities>
+          <h:PowerStatesSupported>5</h:PowerStatesSupported>
+          <h:PowerStatesSupported>8</h:PowerStatesSupported>
+          <h:PowerStatesSupported>2</h:PowerStatesSupported>
+          <h:PowerStatesSupported>10</h:PowerStatesSupported>
+          <h:PowerStatesSupported>11</h:PowerStatesSupported>
+          <h:PowerStatesSupported>12</h:PowerStatesSupported>
+          <h:PowerStatesSupported>14</h:PowerStatesSupported>
+          <h:RequestedPowerStatesSupported>5</h:RequestedPowerStatesSupported>
+          <h:RequestedPowerStatesSupported>8</h:RequestedPowerStatesSupported>
+          <h:RequestedPowerStatesSupported>2</h:RequestedPowerStatesSupported>
+          <h:RequestedPowerStatesSupported>10</h:RequestedPowerStatesSupported>
+          <h:RequestedPowerStatesSupported>11</h:RequestedPowerStatesSupported>
+          <h:RequestedPowerStatesSupported>12</h:RequestedPowerStatesSupported>
+          <h:RequestedPowerStatesSupported>14</h:RequestedPowerStatesSupported>
+        </h:CIM_PowerManagementCapabilities>
+      </g:Items>
+    </g:PullResponse>
+  </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/redirectionservice/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/redirectionservice/enumerate.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <a:Header>
+    <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+    <b:RelatesTo>0</b:RelatesTo>
+    <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+    <b:MessageID>uuid:00000000-8086-8086-8086-0000000000C3</b:MessageID>
+    <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_RedirectionService</c:ResourceURI>
+  </a:Header>
+  <a:Body>
+    <g:EnumerateResponse>
+      <g:EnumerationContext>30000000-0000-0000-0000-000000000000</g:EnumerationContext>
+    </g:EnumerateResponse>
+  </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/redirectionservice/get.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/redirectionservice/get.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_RedirectionService" xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <a:Header>
+    <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+    <b:RelatesTo>2</b:RelatesTo>
+    <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</b:Action>
+    <b:MessageID>uuid:00000000-8086-8086-8086-0000000000C5</b:MessageID>
+    <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_RedirectionService</c:ResourceURI>
+  </a:Header>
+  <a:Body>
+    <g:CIM_RedirectionService>
+      <g:CreationClassName>CIM_RedirectionService</g:CreationClassName>
+      <g:ElementName>Intel(r) ME KVM Redirection Service</g:ElementName>
+      <g:EnabledState>3</g:EnabledState>
+      <g:MaxCurrentEnabledSAPs>1</g:MaxCurrentEnabledSAPs>
+      <g:Name>Intel(r) AMT KVM Redirection Service</g:Name>
+      <g:RedirectionServiceType>3</g:RedirectionServiceType>
+      <g:RequestedState>12</g:RequestedState>
+      <g:SharingMode>3</g:SharingMode>
+      <g:SystemCreationClassName>CIM_ComputerSystem</g:SystemCreationClassName>
+      <g:SystemName>Intel(r) AMT</g:SystemName>
+    </g:CIM_RedirectionService>
+  </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/redirectionservice/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/redirectionservice/pull.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_RedirectionService" xmlns:i="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <a:Header>
+    <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+    <b:RelatesTo>1</b:RelatesTo>
+    <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+    <b:MessageID>uuid:00000000-8086-8086-8086-0000000000C4</b:MessageID>
+    <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_RedirectionService</c:ResourceURI>
+  </a:Header>
+  <a:Body>
+    <g:PullResponse>
+      <g:Items>
+        <h:CIM_RedirectionService>
+          <h:CreationClassName>CIM_RedirectionService</h:CreationClassName>
+          <h:ElementName>Intel(r) ME KVM Redirection Service</h:ElementName>
+          <h:EnabledState>3</h:EnabledState>
+          <h:MaxCurrentEnabledSAPs>1</h:MaxCurrentEnabledSAPs>
+          <h:Name>Intel(r) AMT KVM Redirection Service</h:Name>
+          <h:RedirectionServiceType>3</h:RedirectionServiceType>
+          <h:RequestedState>12</h:RequestedState>
+          <h:SharingMode>3</h:SharingMode>
+          <h:SystemCreationClassName>CIM_ComputerSystem</h:SystemCreationClassName>
+          <h:SystemName>Intel(r) AMT</h:SystemName>
+        </h:CIM_RedirectionService>
+      </g:Items>
+      <g:EndOfSequence/>
+    </g:PullResponse>
+  </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/wifi/endpoint/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/wifi/endpoint/enumerate.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>0</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000002</b:MessageID>
+        <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpoint</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:EnumerateResponse>
+            <g:EnumerationContext>C4020000-0000-0000-0000-000000000000</g:EnumerationContext>
+        </g:EnumerateResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/wifi/endpoint/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/wifi/endpoint/pull.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpoint"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>1</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000003</b:MessageID>
+        <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpoint</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:PullResponse>
+            <g:Items>
+                <h:CIM_WiFiEndpoint>
+                    <h:ElementName>CIM_WiFiEndpoint</h:ElementName>
+                </h:CIM_WiFiEndpoint>
+            </g:Items>
+            <g:EndOfSequence></g:EndOfSequence>
+        </g:PullResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/wifi/endpointcapabilities/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/wifi/endpointcapabilities/enumerate.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>0</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000002</b:MessageID>
+        <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpointCapabilities</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:EnumerateResponse>
+            <g:EnumerationContext>C4020000-0000-0000-0000-000000000000</g:EnumerationContext>
+        </g:EnumerateResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/wifi/endpointcapabilities/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/wifi/endpointcapabilities/pull.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpointCapabilities"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>1</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000003</b:MessageID>
+        <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpointCapabilities</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:PullResponse>
+            <g:Items>
+                <h:CIM_WiFiEndpointCapabilities>
+                    <h:ElementName>CIM_WiFiEndpointCapabilities</h:ElementName>
+                </h:CIM_WiFiEndpointCapabilities>
+            </g:Items>
+            <g:EndOfSequence></g:EndOfSequence>
+        </g:PullResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/wifi/portcapabilities/enumerate.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/wifi/portcapabilities/enumerate.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>0</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000002</b:MessageID>
+        <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiPortCapabilities</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:EnumerateResponse>
+            <g:EnumerationContext>C4020000-0000-0000-0000-000000000000</g:EnumerationContext>
+        </g:EnumerateResponse>
+    </a:Body>
+</a:Envelope>

--- a/pkg/wsman/wsmantesting/responses/cim/wifi/portcapabilities/pull.xml
+++ b/pkg/wsman/wsmantesting/responses/cim/wifi/portcapabilities/pull.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+    xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiPortCapabilities"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>1</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000003</b:MessageID>
+        <c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiPortCapabilities</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:PullResponse>
+            <g:Items>
+                <h:CIM_WiFiPortCapabilities>
+                    <h:ElementName>CIM_WiFiPortCapabilities</h:ElementName>
+                </h:CIM_WiFiPortCapabilities>
+            </g:Items>
+            <g:EndOfSequence></g:EndOfSequence>
+        </g:PullResponse>
+    </a:Body>
+</a:Envelope>


### PR DESCRIPTION
Add new package with service, types, decoder, and JSON/YAML marshalling Add unit tests for the newly added package

- Packaged Included
	- CIM_BIOSFeature
	- CIM_EthernetPort
	- CIM_PowerManagementCapabilities
	- CIM_RedirectionService
	- CIM_WiFiEndpoint
	- CIM_WiFiEndpointCapabilities
	- CIM_WiFiEndpointSettings
	- CIM_WiFiPort
	- CIM_WiFiPortCapabilities
