### PR TITLE
feat: add update wifi profile wsman adapter

### DIFF
--- a/pkg/wsman/amt/wifiportconfiguration/decoder.go
+++ b/pkg/wsman/amt/wifiportconfiguration/decoder.go
@@ -10,6 +10,7 @@ package wifiportconfiguration
 const (
 	AMTWiFiPortConfigurationService string = "AMT_WiFiPortConfigurationService"
 	AddWiFiSettings                 string = "AddWiFiSettings"
+	UpdateWiFiSettings              string = "UpdateWiFiSettings"
 	ValueNotFound                   string = "Value not found in map"
 )
 

--- a/pkg/wsman/amt/wifiportconfiguration/service.go
+++ b/pkg/wsman/amt/wifiportconfiguration/service.go
@@ -104,44 +104,10 @@ func (service Service) AddWiFiSettings(wifiEndpointSettings wifi.WiFiEndpointSet
 		input.IEEE8021xSettings = &ieee8021xSettingsInput
 		input.IEEE8021xSettings.H = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_IEEE8021xSettings"
 
-		input.CACredential = &CACredentialRequest{
-			H:       "http://schemas.xmlsoap.org/ws/2004/08/addressing",
-			Address: "default",
-			ReferenceParameters: ReferenceParameters{
-				H:           "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
-				ResourceURI: "http://intel.com/wbem/wscim/1/amt-schema/1/AMT_PublicKeyCertificate",
-				SelectorSet: SelectorSet{
-					H: "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
-					Selector: []Selector{
-						{
-							H:     "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
-							Name:  "InstanceID",
-							Value: caCredential,
-						},
-					},
-				},
-			},
-		}
+		input.CACredential = newCredentialRef(caCredential)
 
 		if clientCredential != "" {
-			input.ClientCredential = &ClientCredentialRequest{
-				H:       "http://schemas.xmlsoap.org/ws/2004/08/addressing",
-				Address: "default",
-				ReferenceParameters: ReferenceParameters{
-					H:           "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
-					ResourceURI: "http://intel.com/wbem/wscim/1/amt-schema/1/AMT_PublicKeyCertificate",
-					SelectorSet: SelectorSet{
-						H: "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
-						Selector: []Selector{
-							{
-								H:     "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
-								Name:  "InstanceID",
-								Value: clientCredential,
-							},
-						},
-					},
-				},
-			}
+			input.ClientCredential = newClientCredentialRef(clientCredential)
 		}
 	}
 
@@ -171,6 +137,89 @@ func (service Service) AddWiFiSettings(wifiEndpointSettings wifi.WiFiEndpointSet
 	return response, err
 }
 
+// UpdateWiFiSettings Atomically updates the referenced instance of CIM_WifiEndpointSettings from the embedded
+// instance of CIM_WiFiEndPointSettings and updates the referenced instance of CIM_IEEE8021xSettings from the
+// embedded instance of CIM_IEEE8021xSettings.
+//
+// The profile name can't be updated
+//
+// Additional Notes:
+//
+// 1) 'UpdateWiFiSettings' in Intel AMT Release 6.0 and later releases is permitted only to
+// 'ADMIN_SECURITY_ADMINISTRATION_REALM' and 'ADMIN_SECURITY_LOCAL_SYSTEM_REALM '
+//
+// 2) When selecting the value EAP-TLS or EAP-FAST/TLS in AuthenticationProtocol property in
+// IEEE8021xSettings - ClientCredential is mandatory.
+//
+// ValueMap={0, 1, 2, 3, 4, .., 32768..65535}
+//
+// Values={Completed with No Error, Not Supported, Failed, Invalid Parameter, Invalid Reference,
+// Method Reserved, Vendor Specific}.
+func (service Service) UpdateWiFiSettings(wifiEndpointSettings wifi.WiFiEndpointSettingsRequest, ieee8021xSettingsInput models.IEEE8021xSettings, clientCredential, caCredential string) (response Response, err error) {
+	header := service.Base.WSManMessageCreator.CreateHeader(methods.GenerateAction(AMTWiFiPortConfigurationService, UpdateWiFiSettings), AMTWiFiPortConfigurationService, nil, "", "")
+	input := UpdateWiFiSettings_INPUT{
+		WiFiEndpointSettings: WiFiEndpointSettings{
+			Address: "/wsman",
+			ReferenceParameters: ReferenceParameters{
+				H:           "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
+				ResourceURI: fmt.Sprintf("%s%s", message.CIMSchema, wifi.CIMWiFiEndpointSettings),
+				SelectorSet: SelectorSet{
+					H: "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
+					Selector: []Selector{
+						{
+							H:     "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
+							Name:  "InstanceID",
+							Value: wifiEndpointSettings.InstanceID,
+						},
+					},
+				},
+			},
+		},
+		WiFiEndpointSettingsInput: wifiEndpointSettings,
+	}
+
+	input.WiFiEndpointSettingsInput.H = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpointSettings"
+
+	if wifiEndpointSettings.AuthenticationMethod == wifi.AuthenticationMethodWPAIEEE8021x ||
+		wifiEndpointSettings.AuthenticationMethod == wifi.AuthenticationMethodWPA2IEEE8021x {
+		input.IEEE8021xSettings = &ieee8021xSettingsInput
+		input.IEEE8021xSettings.H = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_IEEE8021xSettings"
+
+		if caCredential != "" {
+			input.CACredential = newCredentialRef(caCredential)
+		}
+
+		if clientCredential != "" {
+			input.ClientCredential = newClientCredentialRef(clientCredential)
+		}
+	}
+
+	body := service.Base.WSManMessageCreator.CreateBody(methods.GenerateInputMethod(UpdateWiFiSettings), AMTWiFiPortConfigurationService, &input)
+	response = Response{
+		Message: &client.Message{
+			XMLInput: service.Base.WSManMessageCreator.CreateXML(header, body),
+		},
+	}
+
+	// send the message to AMT
+	err = service.Base.Execute(response.Message)
+	if err != nil {
+		return response, err
+	}
+
+	// put the xml response into the go struct
+	err = xml.Unmarshal([]byte(response.XMLOutput), &response)
+	if err != nil {
+		return response, err
+	}
+
+	if response.Body.UpdateWiFiSettingsOutput.ReturnValue != 0 {
+		err = generateErrorMessage("updatewifisettings", response.Body.UpdateWiFiSettingsOutput.ReturnValue)
+	}
+
+	return response, err
+}
+
 // generateErrorMessage returns an error message based on the return value.
 func generateErrorMessage(call string, returnValue ReturnValue) error {
 	ErrCallFailure := errors.New(call + " failed")
@@ -178,7 +227,37 @@ func generateErrorMessage(call string, returnValue ReturnValue) error {
 	return fmt.Errorf("%w: returned %d", ErrCallFailure, returnValue)
 }
 
-// TODO: Add UpdateWiFiSettings
+func newCredentialRef(instanceID string) *CACredentialRequest {
+	return &CACredentialRequest{
+		H:       "http://schemas.xmlsoap.org/ws/2004/08/addressing",
+		Address: "default",
+		ReferenceParameters: ReferenceParameters{
+			H:           "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
+			ResourceURI: "http://intel.com/wbem/wscim/1/amt-schema/1/AMT_PublicKeyCertificate",
+			SelectorSet: SelectorSet{
+				H: "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
+				Selector: []Selector{
+					{
+						H:     "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
+						Name:  "InstanceID",
+						Value: instanceID,
+					},
+				},
+			},
+		},
+	}
+}
+
+func newClientCredentialRef(instanceID string) *ClientCredentialRequest {
+	credentialRef := newCredentialRef(instanceID)
+
+	return &ClientCredentialRequest{
+		H:                   credentialRef.H,
+		Address:             credentialRef.Address,
+		ReferenceParameters: credentialRef.ReferenceParameters,
+	}
+}
+
 // TODO: Add DeleteAllITProfiles
 // TODO: Add DeleteAllUserProfiles
 // TODO: Add SetApplicationRequestedRfKill

--- a/pkg/wsman/amt/wifiportconfiguration/service_test.go
+++ b/pkg/wsman/amt/wifiportconfiguration/service_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/device-management-toolkit/go-wsman-messages/v2/internal/message"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/methods"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/models"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/wifi"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/common"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/wsmantesting"
 )
@@ -23,7 +26,7 @@ func TestJson(t *testing.T) {
 			WiFiPortConfigurationService: WiFiPortConfigurationServiceResponse{},
 		},
 	}
-	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"WiFiPortConfigurationService\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"RequestedState\":0,\"EnabledState\":0,\"HealthState\":0,\"ElementName\":\"\",\"SystemCreationClassName\":\"\",\"SystemName\":\"\",\"CreationClassName\":\"\",\"Name\":\"\",\"LocalProfileSynchronizationEnabled\":0,\"LastConnectedSsidUnderMeControl\":\"\",\"NoHostCsmeSoftwarePolicy\":0,\"UEFIWiFiProfileShareEnabled\":false},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"WiFiPortConfigurationItems\":null},\"EnumerateResponse\":{\"EnumerationContext\":\"\"},\"AddWiFiSettingsOutput\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"ReturnValue\":0}}"
+	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"WiFiPortConfigurationService\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"RequestedState\":0,\"EnabledState\":0,\"HealthState\":0,\"ElementName\":\"\",\"SystemCreationClassName\":\"\",\"SystemName\":\"\",\"CreationClassName\":\"\",\"Name\":\"\",\"LocalProfileSynchronizationEnabled\":0,\"LastConnectedSsidUnderMeControl\":\"\",\"NoHostCsmeSoftwarePolicy\":0,\"UEFIWiFiProfileShareEnabled\":false},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"WiFiPortConfigurationItems\":null},\"EnumerateResponse\":{\"EnumerationContext\":\"\"},\"AddWiFiSettingsOutput\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"ReturnValue\":0},\"UpdateWiFiSettingsOutput\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"ReturnValue\":0}}"
 	result := response.JSON()
 	assert.Equal(t, expectedResult, result)
 }
@@ -34,9 +37,77 @@ func TestYaml(t *testing.T) {
 			WiFiPortConfigurationService: WiFiPortConfigurationServiceResponse{},
 		},
 	}
-	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\nwifiportconfigurationservice:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    requestedstate: 0\n    enabledstate: 0\n    healthstate: 0\n    elementname: \"\"\n    systemcreationclassname: \"\"\n    systemname: \"\"\n    creationclassname: \"\"\n    name: \"\"\n    localprofilesynchronizationenabled: 0\n    lastconnectedssidundermecontrol: \"\"\n    nohostcsmesoftwarepolicy: 0\n    uefiwifiprofileshareenabled: false\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    wifiportconfigurationitems: []\nenumerateresponse:\n    enumerationcontext: \"\"\naddwifisettingsoutput:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    returnvalue: 0\n"
+	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\nwifiportconfigurationservice:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    requestedstate: 0\n    enabledstate: 0\n    healthstate: 0\n    elementname: \"\"\n    systemcreationclassname: \"\"\n    systemname: \"\"\n    creationclassname: \"\"\n    name: \"\"\n    localprofilesynchronizationenabled: 0\n    lastconnectedssidundermecontrol: \"\"\n    nohostcsmesoftwarepolicy: 0\n    uefiwifiprofileshareenabled: false\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    wifiportconfigurationitems: []\nenumerateresponse:\n    enumerationcontext: \"\"\naddwifisettingsoutput:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    returnvalue: 0\nupdatewifisettingsoutput:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    returnvalue: 0\n"
 	result := response.YAML()
 	assert.Equal(t, expectedResult, result)
+}
+
+func TestUpdateWiFiSettings(t *testing.T) {
+	resourceURIBase := wsmantesting.AMTResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "amt/wifiportconfiguration",
+		CurrentMessage:   "UpdateWiFiSettings",
+	}
+	elementUnderTest := NewWiFiPortConfigurationServiceWithClient(wsmanMessageCreator, &client)
+	expectedXMLInput := wsmantesting.ExpectedResponse(
+		0,
+		resourceURIBase,
+		AMTWiFiPortConfigurationService,
+		methods.GenerateAction(AMTWiFiPortConfigurationService, UpdateWiFiSettings),
+		"",
+		"<h:UpdateWiFiSettings_INPUT xmlns:h=\"http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService\"><h:WiFiEndpointSettings><a:Address>/wsman</a:Address><a:ReferenceParameters xmlns:c=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\"><c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpointSettings</c:ResourceURI><c:SelectorSet xmlns:c=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\"><c:Selector xmlns:c=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\" Name=\"InstanceID\">Intel(r) AMT:WiFi Endpoint Settings home</c:Selector></c:SelectorSet></a:ReferenceParameters></h:WiFiEndpointSettings><h:WiFiEndpointSettingsInput xmlns:q=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpointSettings\"><q:ElementName>home</q:ElementName><q:InstanceID>Intel(r) AMT:WiFi Endpoint Settings home</q:InstanceID><q:AuthenticationMethod>6</q:AuthenticationMethod><q:EncryptionMethod>4</q:EncryptionMethod><q:SSID>admin</q:SSID><q:Priority>1</q:Priority><q:PSKPassPhrase>password123</q:PSKPassPhrase></h:WiFiEndpointSettingsInput></h:UpdateWiFiSettings_INPUT>",
+	)
+
+	wifiEndpointSettings := wifi.WiFiEndpointSettingsRequest{
+		ElementName:          "home",
+		InstanceID:           "Intel(r) AMT:WiFi Endpoint Settings home",
+		AuthenticationMethod: wifi.AuthenticationMethodWPA2PSK,
+		EncryptionMethod:     wifi.EncryptionMethodCCMP,
+		SSID:                 "admin",
+		Priority:             1,
+		PSKPassPhrase:        "password123",
+	}
+
+	response, err := elementUnderTest.UpdateWiFiSettings(
+		wifiEndpointSettings,
+		models.IEEE8021xSettings{},
+		"",
+		"",
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedXMLInput, response.XMLInput)
+	assert.Equal(t, ReturnValueCompletedNoError, response.Body.UpdateWiFiSettingsOutput.ReturnValue)
+}
+
+func TestUpdateWiFiSettings_OmitsCACredentialWhenEmpty(t *testing.T) {
+	resourceURIBase := wsmantesting.AMTResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "amt/wifiportconfiguration",
+		CurrentMessage:   "UpdateWiFiSettings",
+	}
+	elementUnderTest := NewWiFiPortConfigurationServiceWithClient(wsmanMessageCreator, &client)
+
+	wifiEndpointSettings := wifi.WiFiEndpointSettingsRequest{
+		ElementName:          "home",
+		InstanceID:           "Intel(r) AMT:WiFi Endpoint Settings home",
+		AuthenticationMethod: wifi.AuthenticationMethodWPA2IEEE8021x,
+		EncryptionMethod:     wifi.EncryptionMethodCCMP,
+		SSID:                 "admin",
+		Priority:             1,
+	}
+
+	response, err := elementUnderTest.UpdateWiFiSettings(
+		wifiEndpointSettings,
+		models.IEEE8021xSettings{},
+		"client-cert-id",
+		"",
+	)
+	assert.NoError(t, err)
+	assert.NotContains(t, response.XMLInput, "<h:CACredential>")
+	assert.Contains(t, response.XMLInput, "<h:ClientCredential ")
+	assert.Equal(t, ReturnValueCompletedNoError, response.Body.UpdateWiFiSettingsOutput.ReturnValue)
 }
 
 func TestPositiveAMT_WiFiPortConfigurationService(t *testing.T) {

--- a/pkg/wsman/amt/wifiportconfiguration/types.go
+++ b/pkg/wsman/amt/wifiportconfiguration/types.go
@@ -36,6 +36,7 @@ type (
 		PullResponse                 PullResponse
 		EnumerateResponse            common.EnumerateResponse
 		AddWiFiSettingsOutput        AddWiFiSettings_OUTPUT
+		UpdateWiFiSettingsOutput     UpdateWiFiSettings_OUTPUT
 	}
 	WiFiPortConfigurationServiceResponse struct {
 		XMLName                            xml.Name                           `xml:"AMT_WiFiPortConfigurationService"`
@@ -66,6 +67,17 @@ type (
 
 		// ClientCredential     *ClientCredential         `xml:"g:ClientCredential,omitempty"`
 		// CACredential         *CACredential             `xml:"g:CACredential,omitempty"`
+		ReturnValue ReturnValue `xml:"ReturnValue"`
+	}
+
+	// ValueMap={0, 1, 2, 3, 4, .., 32768..65535}
+	//
+	// Values={Completed with No Error, Not Supported, Failed, Invalid Parameter, Invalid Reference, Method Reserved, Vendor Specific}.
+	UpdateWiFiSettings_OUTPUT struct {
+		XMLName xml.Name `xml:"UpdateWiFiSettings_OUTPUT"`
+		// not concerned with these entries on OUTPUT
+
+		// IEEE8021xSettings    *IEEE8021xSettingsRef `xml:"g:IEEE8021xSettings,omitempty"`
 		ReturnValue ReturnValue `xml:"ReturnValue"`
 	}
 )
@@ -163,6 +175,16 @@ type (
 		ClientCredential     *ClientCredentialRequest  `xml:"h:ClientCredential,omitempty"`
 		CACredential         *CACredentialRequest      `xml:"h:CACredential,omitempty"`
 	}
+
+	UpdateWiFiSettings_INPUT struct {
+		XMLName                   xml.Name `xml:"h:UpdateWiFiSettings_INPUT"`
+		H                         string   `xml:"xmlns:h,attr"`
+		WiFiEndpointSettings      WiFiEndpointSettings
+		WiFiEndpointSettingsInput wifi.WiFiEndpointSettingsRequest
+		IEEE8021xSettings         *models.IEEE8021xSettings `xml:"h:IEEE8021xSettingsInput,omitempty"`
+		ClientCredential          *ClientCredentialRequest  `xml:"h:ClientCredential,omitempty"`
+		CACredential              *CACredentialRequest      `xml:"h:CACredential,omitempty"`
+	}
 	WiFiPortConfigurationServiceRequest struct {
 		XMLName                            xml.Name                           `xml:"h:AMT_WiFiPortConfigurationService"`
 		H                                  string                             `xml:"xmlns:h,attr"`
@@ -220,6 +242,13 @@ type (
 // The endpoint to associate the new settings with.
 type WiFiEndpoint struct {
 	XMLName             xml.Name            `xml:"h:WiFiEndpoint,omitempty"`
+	Address             string              `xml:"a:Address,omitempty"`
+	ReferenceParameters ReferenceParameters `xml:"a:ReferenceParameters,omitempty"`
+}
+
+// The endpoint settings instance to update.
+type WiFiEndpointSettings struct {
+	XMLName             xml.Name            `xml:"h:WiFiEndpointSettings,omitempty"`
 	Address             string              `xml:"a:Address,omitempty"`
 	ReferenceParameters ReferenceParameters `xml:"a:ReferenceParameters,omitempty"`
 }

--- a/pkg/wsman/wsmantesting/responses/amt/wifiportconfiguration/updatewifisettings.xml
+++ b/pkg/wsman/wsmantesting/responses/amt/wifiportconfiguration/updatewifisettings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService"
+    xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/common"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>5</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService/UpdateWiFiSettingsResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000002965</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:UpdateWiFiSettings_OUTPUT>
+            <g:ReturnValue>0</g:ReturnValue>
+        </g:UpdateWiFiSettings_OUTPUT>
+    </a:Body>
+</a:Envelope>


### PR DESCRIPTION
## Change Summary

- added UpdateWiFiSettings in wifiportconfiguration service

## Testing

NOTE: tested using console wifi profile management API [PR#921](https://github.com/device-management-toolkit/console/pull/921)

- non-IEEE8021x

1. current profile:

```bash
{"ProfileName":"WiAMT2","SSID":"WiAMT2","Password":"","AuthenticationMethod":"WPA2PSK","EncryptionMethod":"CCMP","Priority":20,"IEEE8021x":null}
```

2. updated profile:

```bash
{"ProfileName":"WiAMT2","SSID":"WiAMT","Password":"","AuthenticationMethod":"WPA2PSK","EncryptionMethod":"CCMP","Priority":30,"IEEE8021x":null}
```

- IEEE8021x

1. current profile:

```bash
{"ProfileName":"CorpEAP3","SSID":"CorpNet3","Password":"","AuthenticationMethod":"WPA2IEEE8021x","EncryptionMethod":"CCMP","Priority":50,"IEEE8021x":{"Username":"corpuser3","Password":"","AuthenticationProtocol":2,"ClientCert":"","CACert":"","PrivateKey":"","PXETimeout":0}}
```

2. updated profile:

```bash
{"ProfileName":"CorpEAP3","SSID":"CorpNet3","Password":"","AuthenticationMethod":"WPA2IEEE8021x","EncryptionMethod":"CCMP","Priority":60,"IEEE8021x":{"Username":"corpuser3","Password":"","AuthenticationProtocol":0,"ClientCert":"","CACert":"","PrivateKey":"","PXETimeout":0}}
```