### PR TITLE
ci: disable goconst

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
     - exhaustive
     - forbidigo
     - gochecknoinits
-    - goconst
     - godot
     - gomodguard
     - goprintffuncname
@@ -82,6 +81,7 @@ linters:
       - linters:
           - err113
           - funlen
+          - goconst
         path: (.+)_test.go
     paths:
       - docs


### PR DESCRIPTION
This linter is asking a bit much especially when it comes to test. We can reenable at a later time.