### PR TITLE
fix: bump Go version to 1.26.3 to address CVE-2026-27143

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.25]
+        go-version: [1.26]
         os: [windows-2019, windows-2022, ubuntu-22.04, ubuntu-20.04]
     steps:
       - name: Harden Runner

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.26.x]
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write  # for Git to git push
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.26.x]
 
     steps:
     - name: Harden Runner

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/device-management-toolkit/go-wsman-messages/v2
 
-go 1.25
+go 1.26.3
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Arithmetic over induction variables in loops were not correctly checked for underflow or overflow, potentially leading to memory corruption.