### PR TITLE
fix: Remove omitempty from UEFIWiFiProfileShareEnabled

### DIFF
--- a/pkg/wsman/amt/wifiportconfiguration/service_test.go
+++ b/pkg/wsman/amt/wifiportconfiguration/service_test.go
@@ -149,7 +149,7 @@ func TestPositiveAMT_WiFiPortConfigurationService(t *testing.T) {
 				"should create a valid AMT_WiFiPortConfigurationService Put wsman message",
 				AMTWiFiPortConfigurationService,
 				wsmantesting.Put,
-				"<h:AMT_WiFiPortConfigurationService xmlns:h=\"http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService\"><h:RequestedState>12</h:RequestedState><h:EnabledState>5</h:EnabledState><h:HealthState>5</h:HealthState><h:ElementName>Intel(r) AMT WiFiPort Configuration Service</h:ElementName><h:SystemCreationClassName>CIM_ComputerSystem</h:SystemCreationClassName><h:SystemName>Intel(r) AMT</h:SystemName><h:CreationClassName>AMT_WiFiPortConfigurationService</h:CreationClassName><h:Name>Intel(r) AMT WiFi Port Configuration Service</h:Name><h:localProfileSynchronizationEnabled>1</h:localProfileSynchronizationEnabled></h:AMT_WiFiPortConfigurationService>",
+				"<h:AMT_WiFiPortConfigurationService xmlns:h=\"http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService\"><h:RequestedState>12</h:RequestedState><h:EnabledState>5</h:EnabledState><h:HealthState>5</h:HealthState><h:ElementName>Intel(r) AMT WiFiPort Configuration Service</h:ElementName><h:SystemCreationClassName>CIM_ComputerSystem</h:SystemCreationClassName><h:SystemName>Intel(r) AMT</h:SystemName><h:CreationClassName>AMT_WiFiPortConfigurationService</h:CreationClassName><h:Name>Intel(r) AMT WiFi Port Configuration Service</h:Name><h:localProfileSynchronizationEnabled>1</h:localProfileSynchronizationEnabled><h:UEFIWiFiProfileShareEnabled>false</h:UEFIWiFiProfileShareEnabled></h:AMT_WiFiPortConfigurationService>",
 				"",
 				func() (Response, error) {
 					client.CurrentMessage = wsmantesting.CurrentMessagePut

--- a/pkg/wsman/amt/wifiportconfiguration/types.go
+++ b/pkg/wsman/amt/wifiportconfiguration/types.go
@@ -177,7 +177,7 @@ type (
 		LocalProfileSynchronizationEnabled LocalProfileSynchronizationEnabled `xml:"h:localProfileSynchronizationEnabled"`        // Administrator's policy regarding enablement of local profile synchronization.Remote profile synchronization is always enabled.
 		LastConnectedSsidUnderMeControl    string                             `xml:"h:LastConnectedSsidUnderMeControl,omitempty"` // The SSID of the Wireless network that was last connected in ME Control state
 		NoHostCsmeSoftwarePolicy           NoHostCsmeSoftwarePolicy           `xml:"h:NoHostCsmeSoftwarePolicy,omitempty"`        // Setting Policy regarding no HOST CSME software.
-		UEFIWiFiProfileShareEnabled        bool                               `xml:"h:UEFIWiFiProfileShareEnabled,omitempty"`     // Enables or disables UEFI/CSME Wi-Fi Profile Sharing. The feature is available from Intel® CSME 16.0. The feature can be disabled even if the value of AMT_BootCapabilities.UEFIWiFiCoExistenceAndProfileShare is False.
+		UEFIWiFiProfileShareEnabled        bool                               `xml:"h:UEFIWiFiProfileShareEnabled"`               // Enables or disables UEFI/CSME Wi-Fi Profile Sharing. The feature is available from Intel® CSME 16.0. The feature can be disabled even if the value of AMT_BootCapabilities.UEFIWiFiCoExistenceAndProfileShare is False.
 	}
 
 	// a Reference to an AMT_PublicKeyCertificate, which represents the CA certificate.


### PR DESCRIPTION
## PR Objective

- To resolve issue #704 

## Change Summary

- Removed omitempty from UEFIWiFiProfileShareEnabled 
- Updated respective unit test

## Testing

Tested passed on target

```bash
# get UEFIWiFiProfileShareEnabled value
curl -sS "http://localhost:8181/api/v1/amt/networkSettings/wireless/uefiProfileSync/$GUID" -H "Authorization: Bearer $(curl -sS -X POST "http://localhost:8181/api/v1/authorize" -H "Content-Type: application/json" -d "$(printf '{"username":"%s","password":"%s"}' "$USER" "$PASS")" | jq -r '.token')"
{"enabled":true}

# set UEFIWiFiProfileShareEnabled value to false
curl -sS -X POST "http://localhost:8181/api/v1/amt/networkSettings/wireless/uefiProfileSync/$GUID" -H "Content-Type: application/json" -H "Authorization: Bearer $(curl -sS -X POST "http://localhost:8181/api/v1/authorize" -H "Content-Type: application/json" -d "$(printf '{"username":"%s","password":"%s"}' "$USER" "$PASS")" | jq -r '.token')" -d '{"enabled":false}'
{"enabled":false}
```