### PR TITLE
fix: Remove wiFiPortConfigurationService Put post-processes check

### DIFF
--- a/pkg/wsman/amt/wifiportconfiguration/service.go
+++ b/pkg/wsman/amt/wifiportconfiguration/service.go
@@ -27,8 +27,7 @@ func NewWiFiPortConfigurationServiceWithClient(wsmanMessageCreator *message.WSMa
 }
 
 // Put overrides the generic Put because it has a strongly-typed request
-// parameter (value receiver) and post-processes the response to surface a
-// specific error when LocalProfileSynchronizationEnabled is not set.
+// parameter that is passed by value.
 func (service Service) Put(wiFiPortConfigurationService WiFiPortConfigurationServiceRequest) (response Response, err error) {
 	// wiFiPortConfigurationService.XMLSchema = "http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService"
 	wiFiPortConfigurationService.H = fmt.Sprintf("%s%s", message.AMTSchema, AMTWiFiPortConfigurationService)
@@ -48,10 +47,6 @@ func (service Service) Put(wiFiPortConfigurationService WiFiPortConfigurationSer
 	err = xml.Unmarshal([]byte(response.XMLOutput), &response)
 	if err != nil {
 		return response, err
-	}
-
-	if response.Body.WiFiPortConfigurationService.LocalProfileSynchronizationEnabled == 0 {
-		err = errors.New("failed to enable wifi local profile synchronization")
 	}
 
 	return response, err

--- a/pkg/wsman/amt/wifiportconfiguration/service_test.go
+++ b/pkg/wsman/amt/wifiportconfiguration/service_test.go
@@ -258,6 +258,48 @@ func TestPositiveAMT_WiFiPortConfigurationService(t *testing.T) {
 					},
 				},
 			},
+			{
+				"should not return error when Put response local profile sync is disabled",
+				AMTWiFiPortConfigurationService,
+				wsmantesting.Put,
+				"<h:AMT_WiFiPortConfigurationService xmlns:h=\"http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService\"><h:RequestedState>12</h:RequestedState><h:EnabledState>5</h:EnabledState><h:HealthState>5</h:HealthState><h:ElementName>Intel(r) AMT WiFiPort Configuration Service</h:ElementName><h:SystemCreationClassName>CIM_ComputerSystem</h:SystemCreationClassName><h:SystemName>Intel(r) AMT</h:SystemName><h:CreationClassName>AMT_WiFiPortConfigurationService</h:CreationClassName><h:Name>Intel(r) AMT WiFi Port Configuration Service</h:Name><h:localProfileSynchronizationEnabled>1</h:localProfileSynchronizationEnabled><h:UEFIWiFiProfileShareEnabled>false</h:UEFIWiFiProfileShareEnabled></h:AMT_WiFiPortConfigurationService>",
+				"",
+				func() (Response, error) {
+					client.CurrentMessage = "PutLocalProfileSyncDisabled"
+					wifiConfiguration := WiFiPortConfigurationServiceRequest{
+						RequestedState:                     12,
+						EnabledState:                       5,
+						HealthState:                        5,
+						ElementName:                        "Intel(r) AMT WiFiPort Configuration Service",
+						SystemCreationClassName:            "CIM_ComputerSystem",
+						SystemName:                         "Intel(r) AMT",
+						CreationClassName:                  "AMT_WiFiPortConfigurationService",
+						Name:                               "Intel(r) AMT WiFi Port Configuration Service",
+						LocalProfileSynchronizationEnabled: 1,
+						LastConnectedSsidUnderMeControl:    "",
+						NoHostCsmeSoftwarePolicy:           0,
+					}
+
+					return elementUnderTest.Put(wifiConfiguration)
+				},
+				Body{
+					XMLName: xml.Name{Space: message.XMLBodySpace, Local: "Body"},
+					WiFiPortConfigurationService: WiFiPortConfigurationServiceResponse{
+						XMLName:                            xml.Name{Space: fmt.Sprintf("%s%s", message.AMTSchema, AMTWiFiPortConfigurationService), Local: AMTWiFiPortConfigurationService},
+						CreationClassName:                  "AMT_WiFiPortConfigurationService",
+						ElementName:                        "Intel(r) AMT WiFiPort Configuration Service",
+						EnabledState:                       5,
+						HealthState:                        5,
+						LastConnectedSsidUnderMeControl:    "",
+						Name:                               "Intel(r) AMT WiFi Port Configuration Service",
+						NoHostCsmeSoftwarePolicy:           0,
+						RequestedState:                     12,
+						SystemCreationClassName:            "CIM_ComputerSystem",
+						SystemName:                         "Intel(r) AMT",
+						LocalProfileSynchronizationEnabled: 0,
+					},
+				},
+			},
 			// WIFI PORT CONFIGURATION SERVICE
 			// {
 			// 	"should return a valid amt_WiFiPortConfigurationService ADD_WIFI_SETTINGS wsman message",

--- a/pkg/wsman/wsmantesting/responses/amt/wifiportconfiguration/putlocalprofilesyncdisabled.xml
+++ b/pkg/wsman/wsmantesting/responses/amt/wifiportconfiguration/putlocalprofilesyncdisabled.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService"
+    xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/common"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>5</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/PutResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000002965</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:AMT_WiFiPortConfigurationService>
+            <g:CreationClassName>AMT_WiFiPortConfigurationService</g:CreationClassName>
+            <g:ElementName>Intel(r) AMT WiFiPort Configuration Service</g:ElementName>
+            <g:EnabledState>5</g:EnabledState>
+            <g:HealthState>5</g:HealthState>
+            <g:LastConnectedSsidUnderMeControl></g:LastConnectedSsidUnderMeControl>
+            <g:Name>Intel(r) AMT WiFi Port Configuration Service</g:Name>
+            <g:NoHostCsmeSoftwarePolicy>0</g:NoHostCsmeSoftwarePolicy>
+            <g:RequestedState>12</g:RequestedState>
+            <g:SystemCreationClassName>CIM_ComputerSystem</g:SystemCreationClassName>
+            <g:SystemName>Intel(r) AMT</g:SystemName>
+            <g:localProfileSynchronizationEnabled>0</g:localProfileSynchronizationEnabled>
+        </g:AMT_WiFiPortConfigurationService>
+    </a:Body>
+</a:Envelope>


### PR DESCRIPTION
## PR Objective

- To resolve issue #703 

## Change Summary

- Removed wiFiPortConfigurationService Put post-processes LocalProfileSynchronizationEnabled check including related  comments
- Added a regression test that exercises Put returning localProfileSynchronizationEnabled=0 and asserts no error

## Testing

Tested passed on-target

```bash
# get LocalProfileSynchronizationEnabled value
curl -sS "http://localhost:8181/api/v1/amt/networkSettings/wireless/localProfileSync/$GUID" -H "Authorization: Bearer $(curl -sS -X POST "http://localhost:8181/api/v1/authorize" -H "Content-Type: application/json" -d "$(printf '{"username":"%s","password":"%s"}' "$USER" "$PASS")" | jq -r '.token')"
{"enabled":true}

# set LocalProfileSynchronizationEnabled to false
curl -sS -X POST "http://localhost:8181/api/v1/amt/networkSettings/wireless/localProfileSync/$GUID" -H "Content-Type: application/json" -H "Authorization: Bearer $(curl -sS -X POST "http://localhost:8181/api/v1/authorize" -H "Content-Type: application/json" -d "$(printf '{"username":"%s","password":"%s"}' "$USER" "$PASS")" | jq -r '.token')" -d '{"enabled":false}'
{"enabled":false}
```