### PR TITLE
ci(config): add Dependabot cooldown settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Configure cooldown.default-days: 7 for gomod and github-actions updaters in .github/dependabot.yml to satisfy zizmor dependabot-cooldown.

https://github.com/device-management-toolkit/go-wsman-messages/security/code-scanning/69
https://github.com/device-management-toolkit/go-wsman-messages/security/code-scanning/70