### PR TITLE
ci(deps): group codeql-action sub-action updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    # codeql-action's sub-actions release in lockstep; one PR instead of four.
+    groups:
+      codeql-action:
+        patterns:
+          - 'github/codeql-action*'


### PR DESCRIPTION
github/codeql-action/{init,analyze,autobuild,upload-sarif} are released in lockstep from one repo but land as separate dependabot PRs. Group them so each bump opens a single PR.