### PR TITLE
fix(amt): omit empty CACredential in AddWiFiSettings

### DIFF
--- a/pkg/wsman/amt/wifiportconfiguration/service.go
+++ b/pkg/wsman/amt/wifiportconfiguration/service.go
@@ -99,7 +99,9 @@ func (service Service) AddWiFiSettings(wifiEndpointSettings wifi.WiFiEndpointSet
 		input.IEEE8021xSettings = &ieee8021xSettingsInput
 		input.IEEE8021xSettings.H = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_IEEE8021xSettings"
 
-		input.CACredential = newCredentialRef(caCredential)
+		if caCredential != "" {
+			input.CACredential = newCredentialRef(caCredential)
+		}
 
 		if clientCredential != "" {
 			input.ClientCredential = newClientCredentialRef(clientCredential)

--- a/pkg/wsman/amt/wifiportconfiguration/service.go
+++ b/pkg/wsman/amt/wifiportconfiguration/service.go
@@ -73,40 +73,18 @@ func (service Service) AddWiFiSettings(wifiEndpointSettings wifi.WiFiEndpointSet
 	header := service.Base.WSManMessageCreator.CreateHeader(methods.GenerateAction(AMTWiFiPortConfigurationService, AddWiFiSettings), AMTWiFiPortConfigurationService, nil, "", "")
 	input := AddWiFiSettings_INPUT{
 		WifiEndpoint: WiFiEndpoint{
-			Address: "/wsman",
-			ReferenceParameters: ReferenceParameters{
-				H:           "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
-				ResourceURI: fmt.Sprintf("%s%s", message.CIMSchema, wifi.CIMWiFiEndpoint),
-				SelectorSet: SelectorSet{
-					H: "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
-					Selector: []Selector{
-						{
-							H:     "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
-							Name:  "Name",
-							Value: wifiEndpoint,
-						},
-					},
-				},
-			},
+			Address:             "/wsman",
+			ReferenceParameters: newReferenceParameters(fmt.Sprintf("%s%s", message.CIMSchema, wifi.CIMWiFiEndpoint), "Name", wifiEndpoint),
 		},
 		WiFiEndpointSettings: wifiEndpointSettings,
 	}
 
 	input.WiFiEndpointSettings.H = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpointSettings"
 
-	if wifiEndpointSettings.AuthenticationMethod == wifi.AuthenticationMethodWPAIEEE8021x ||
-		wifiEndpointSettings.AuthenticationMethod == wifi.AuthenticationMethodWPA2IEEE8021x {
-		input.IEEE8021xSettings = &ieee8021xSettingsInput
-		input.IEEE8021xSettings.H = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_IEEE8021xSettings"
-
-		if caCredential != "" {
-			input.CACredential = newCredentialRef(caCredential)
-		}
-
-		if clientCredential != "" {
-			input.ClientCredential = newClientCredentialRef(clientCredential)
-		}
-	}
+	credentials := newIEEE8021xCredentials(wifiEndpointSettings.AuthenticationMethod, ieee8021xSettingsInput, clientCredential, caCredential)
+	input.IEEE8021xSettings = credentials.IEEE8021xSettings
+	input.ClientCredential = credentials.ClientCredential
+	input.CACredential = credentials.CACredential
 
 	body := service.Base.WSManMessageCreator.CreateBody(methods.GenerateInputMethod(AddWiFiSettings), AMTWiFiPortConfigurationService, &input)
 	response = Response{
@@ -156,40 +134,18 @@ func (service Service) UpdateWiFiSettings(wifiEndpointSettings wifi.WiFiEndpoint
 	header := service.Base.WSManMessageCreator.CreateHeader(methods.GenerateAction(AMTWiFiPortConfigurationService, UpdateWiFiSettings), AMTWiFiPortConfigurationService, nil, "", "")
 	input := UpdateWiFiSettings_INPUT{
 		WiFiEndpointSettings: WiFiEndpointSettings{
-			Address: "/wsman",
-			ReferenceParameters: ReferenceParameters{
-				H:           "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
-				ResourceURI: fmt.Sprintf("%s%s", message.CIMSchema, wifi.CIMWiFiEndpointSettings),
-				SelectorSet: SelectorSet{
-					H: "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
-					Selector: []Selector{
-						{
-							H:     "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
-							Name:  "InstanceID",
-							Value: wifiEndpointSettings.InstanceID,
-						},
-					},
-				},
-			},
+			Address:             "/wsman",
+			ReferenceParameters: newReferenceParameters(fmt.Sprintf("%s%s", message.CIMSchema, wifi.CIMWiFiEndpointSettings), "InstanceID", wifiEndpointSettings.InstanceID),
 		},
 		WiFiEndpointSettingsInput: wifiEndpointSettings,
 	}
 
 	input.WiFiEndpointSettingsInput.H = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpointSettings"
 
-	if wifiEndpointSettings.AuthenticationMethod == wifi.AuthenticationMethodWPAIEEE8021x ||
-		wifiEndpointSettings.AuthenticationMethod == wifi.AuthenticationMethodWPA2IEEE8021x {
-		input.IEEE8021xSettings = &ieee8021xSettingsInput
-		input.IEEE8021xSettings.H = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_IEEE8021xSettings"
-
-		if caCredential != "" {
-			input.CACredential = newCredentialRef(caCredential)
-		}
-
-		if clientCredential != "" {
-			input.ClientCredential = newClientCredentialRef(clientCredential)
-		}
-	}
+	credentials := newIEEE8021xCredentials(wifiEndpointSettings.AuthenticationMethod, ieee8021xSettingsInput, clientCredential, caCredential)
+	input.IEEE8021xSettings = credentials.IEEE8021xSettings
+	input.ClientCredential = credentials.ClientCredential
+	input.CACredential = credentials.CACredential
 
 	body := service.Base.WSManMessageCreator.CreateBody(methods.GenerateInputMethod(UpdateWiFiSettings), AMTWiFiPortConfigurationService, &input)
 	response = Response{
@@ -253,6 +209,60 @@ func newClientCredentialRef(instanceID string) *ClientCredentialRequest {
 		Address:             credentialRef.Address,
 		ReferenceParameters: credentialRef.ReferenceParameters,
 	}
+}
+
+// newReferenceParameters builds the ReferenceParameters block (ResourceURI plus a single
+// Name/Value selector) shared by the WiFiEndpoint reference used by AddWiFiSettings and the
+// WiFiEndpointSettings reference used by UpdateWiFiSettings.
+func newReferenceParameters(resourceURI, selectorName, selectorValue string) ReferenceParameters {
+	return ReferenceParameters{
+		H:           "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
+		ResourceURI: resourceURI,
+		SelectorSet: SelectorSet{
+			H: "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
+			Selector: []Selector{
+				{
+					H:     "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
+					Name:  selectorName,
+					Value: selectorValue,
+				},
+			},
+		},
+	}
+}
+
+// ieee8021xCredentials holds the optional IEEE 802.1x settings and credential references shared
+// by AddWiFiSettings and UpdateWiFiSettings. All three fields are nil unless the given
+// authentication method is one of the IEEE 802.1x variants.
+type ieee8021xCredentials struct {
+	IEEE8021xSettings *models.IEEE8021xSettings
+	ClientCredential  *ClientCredentialRequest
+	CACredential      *CACredentialRequest
+}
+
+// newIEEE8021xCredentials builds the IEEE 802.1x settings and optional client/CA credential
+// references shared by AddWiFiSettings and UpdateWiFiSettings. clientCredential and caCredential
+// are both optional and must stay gated on a non-empty value here: an empty credential would
+// still produce a <ClientCredential>/<CACredential> reference with a blank InstanceID selector,
+// which AMT firmware rejects as an invalid reference.
+func newIEEE8021xCredentials(authenticationMethod wifi.AuthenticationMethod, ieee8021xSettingsInput models.IEEE8021xSettings, clientCredential, caCredential string) ieee8021xCredentials {
+	if authenticationMethod != wifi.AuthenticationMethodWPAIEEE8021x && authenticationMethod != wifi.AuthenticationMethodWPA2IEEE8021x {
+		return ieee8021xCredentials{}
+	}
+
+	ieee8021xSettingsInput.H = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_IEEE8021xSettings"
+
+	credentials := ieee8021xCredentials{IEEE8021xSettings: &ieee8021xSettingsInput}
+
+	if clientCredential != "" {
+		credentials.ClientCredential = newClientCredentialRef(clientCredential)
+	}
+
+	if caCredential != "" {
+		credentials.CACredential = newCredentialRef(caCredential)
+	}
+
+	return credentials
 }
 
 // TODO: Add DeleteAllITProfiles

--- a/pkg/wsman/amt/wifiportconfiguration/service_test.go
+++ b/pkg/wsman/amt/wifiportconfiguration/service_test.go
@@ -110,6 +110,114 @@ func TestUpdateWiFiSettings_OmitsCACredentialWhenEmpty(t *testing.T) {
 	assert.Equal(t, ReturnValueCompletedNoError, response.Body.UpdateWiFiSettingsOutput.ReturnValue)
 }
 
+func TestAddWiFiSettings(t *testing.T) {
+	resourceURIBase := wsmantesting.AMTResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "amt/wifiportconfiguration",
+		CurrentMessage:   "AddWiFiSettings",
+	}
+	elementUnderTest := NewWiFiPortConfigurationServiceWithClient(wsmanMessageCreator, &client)
+	expectedXMLInput := wsmantesting.ExpectedResponse(
+		0,
+		resourceURIBase,
+		AMTWiFiPortConfigurationService,
+		methods.GenerateAction(AMTWiFiPortConfigurationService, AddWiFiSettings),
+		"",
+		"<h:AddWiFiSettings_INPUT xmlns:h=\"http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService\"><h:WiFiEndpoint><a:Address>/wsman</a:Address><a:ReferenceParameters xmlns:c=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\"><c:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpoint</c:ResourceURI><c:SelectorSet xmlns:c=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\"><c:Selector xmlns:c=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\" Name=\"Name\">WiFi Endpoint 0</c:Selector></c:SelectorSet></a:ReferenceParameters></h:WiFiEndpoint><h:WiFiEndpointSettingsInput xmlns:q=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpointSettings\"><q:ElementName>home</q:ElementName><q:InstanceID>Intel(r) AMT:WiFi Endpoint Settings home</q:InstanceID><q:AuthenticationMethod>6</q:AuthenticationMethod><q:EncryptionMethod>4</q:EncryptionMethod><q:SSID>admin</q:SSID><q:Priority>1</q:Priority><q:PSKPassPhrase>password123</q:PSKPassPhrase></h:WiFiEndpointSettingsInput></h:AddWiFiSettings_INPUT>",
+	)
+
+	wifiEndpointSettings := wifi.WiFiEndpointSettingsRequest{
+		ElementName:          "home",
+		InstanceID:           "Intel(r) AMT:WiFi Endpoint Settings home",
+		AuthenticationMethod: wifi.AuthenticationMethodWPA2PSK,
+		EncryptionMethod:     wifi.EncryptionMethodCCMP,
+		SSID:                 "admin",
+		Priority:             1,
+		PSKPassPhrase:        "password123",
+	}
+
+	response, err := elementUnderTest.AddWiFiSettings(
+		wifiEndpointSettings,
+		models.IEEE8021xSettings{},
+		"WiFi Endpoint 0",
+		"",
+		"",
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedXMLInput, response.XMLInput)
+	assert.Equal(t, ReturnValueCompletedNoError, response.Body.AddWiFiSettingsOutput.ReturnValue)
+}
+
+// TestAddWiFiSettings_OmitsCACredentialWhenEmpty is a regression test: AddWiFiSettings used to send
+// an empty <h:CACredential> reference (with a blank InstanceID selector) whenever an IEEE 802.1x
+// profile was added without a CA certificate, even though the CA certificate is optional. AMT
+// firmware rejects the invalid reference, so every "add" of a new 802.1x profile without a CA cert
+// failed. UpdateWiFiSettings already gated this correctly; AddWiFiSettings must match.
+func TestAddWiFiSettings_OmitsCACredentialWhenEmpty(t *testing.T) {
+	resourceURIBase := wsmantesting.AMTResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "amt/wifiportconfiguration",
+		CurrentMessage:   "AddWiFiSettings",
+	}
+	elementUnderTest := NewWiFiPortConfigurationServiceWithClient(wsmanMessageCreator, &client)
+
+	wifiEndpointSettings := wifi.WiFiEndpointSettingsRequest{
+		ElementName:          "home",
+		InstanceID:           "Intel(r) AMT:WiFi Endpoint Settings home",
+		AuthenticationMethod: wifi.AuthenticationMethodWPA2IEEE8021x,
+		EncryptionMethod:     wifi.EncryptionMethodCCMP,
+		SSID:                 "admin",
+		Priority:             1,
+	}
+
+	response, err := elementUnderTest.AddWiFiSettings(
+		wifiEndpointSettings,
+		models.IEEE8021xSettings{},
+		"WiFi Endpoint 0",
+		"client-cert-id",
+		"",
+	)
+	assert.NoError(t, err)
+	assert.NotContains(t, response.XMLInput, "<h:CACredential>")
+	assert.Contains(t, response.XMLInput, "<h:ClientCredential ")
+	assert.Equal(t, ReturnValueCompletedNoError, response.Body.AddWiFiSettingsOutput.ReturnValue)
+}
+
+// TestAddWiFiSettings_IncludesCACredentialWhenProvided guards the other direction: when a CA
+// certificate handle is supplied, it must still be included in the request.
+func TestAddWiFiSettings_IncludesCACredentialWhenProvided(t *testing.T) {
+	resourceURIBase := wsmantesting.AMTResourceURIBase
+	wsmanMessageCreator := message.NewWSManMessageCreator(resourceURIBase)
+	client := wsmantesting.MockClient{
+		PackageUnderTest: "amt/wifiportconfiguration",
+		CurrentMessage:   "AddWiFiSettings",
+	}
+	elementUnderTest := NewWiFiPortConfigurationServiceWithClient(wsmanMessageCreator, &client)
+
+	wifiEndpointSettings := wifi.WiFiEndpointSettingsRequest{
+		ElementName:          "home",
+		InstanceID:           "Intel(r) AMT:WiFi Endpoint Settings home",
+		AuthenticationMethod: wifi.AuthenticationMethodWPA2IEEE8021x,
+		EncryptionMethod:     wifi.EncryptionMethodCCMP,
+		SSID:                 "admin",
+		Priority:             1,
+	}
+
+	response, err := elementUnderTest.AddWiFiSettings(
+		wifiEndpointSettings,
+		models.IEEE8021xSettings{},
+		"WiFi Endpoint 0",
+		"",
+		"ca-cert-id",
+	)
+	assert.NoError(t, err)
+	assert.Contains(t, response.XMLInput, "<h:CACredential ")
+	assert.NotContains(t, response.XMLInput, "<h:ClientCredential>")
+	assert.Equal(t, ReturnValueCompletedNoError, response.Body.AddWiFiSettingsOutput.ReturnValue)
+}
+
 func TestPositiveAMT_WiFiPortConfigurationService(t *testing.T) {
 	messageID := 0
 	resourceURIBase := wsmantesting.AMTResourceURIBase
@@ -300,23 +408,6 @@ func TestPositiveAMT_WiFiPortConfigurationService(t *testing.T) {
 					},
 				},
 			},
-			// WIFI PORT CONFIGURATION SERVICE
-			// {
-			// 	"should return a valid amt_WiFiPortConfigurationService ADD_WIFI_SETTINGS wsman message",
-			// 	AMT_WiFiPortConfigurationService,
-			// 	`http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService/AddWiFiSettings`, `<h:AddWiFiSettings_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService"><h:WiFiEndpoint><a:Address>/wsman</a:Address><a:ReferenceParameters><w:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpoint</w:ResourceURI><w:SelectorSet><w:Selector Name="Name">WiFi Endpoint 0</w:Selector></w:SelectorSet></a:ReferenceParameters></h:WiFiEndpoint><h:WiFiEndpointSettingsInput xmlns:q="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_WiFiEndpointSettings"><q:ElementName>home</q:ElementName><q:InstanceID>Intel(r) AMT:WiFi Endpoint Settings home</q:InstanceID><q:AuthenticationMethod>6</q:AuthenticationMethod><q:EncryptionMethod>4</q:EncryptionMethod><q:SSID>admin</q:SSID><q:Priority>1</q:Priority><q:PSKPassPhrase>p&#39;ass&lt;&gt;&amp;&#34;code</q:PSKPassPhrase></h:WiFiEndpointSettingsInput></h:AddWiFiSettings_INPUT>`,
-			// 	"",
-			// 	func() (Response, error) {
-			// 		client.CurrentMessage = "AddWiFiSettings"
-			// 		wifiEndpointSettings := wifi.WiFiEndpointSettings_INPUT{}
-			// 		ieee8021xSettings := &models.IEEE8021xSettings{}
-			// 		wifiEndpoint := "t"
-			// 		clientCredential := "t"
-			// 		caCredential := "t"
-			// 		return elementUnderTest.AddWiFiSettings(wifiEndpointSettings, ieee8021xSettings, wifiEndpoint, clientCredential, caCredential)
-			// 	},
-			// 	Body{},
-			// },
 		}
 
 		for _, test := range tests {

--- a/pkg/wsman/wsmantesting/responses/amt/wifiportconfiguration/addwifisettings.xml
+++ b/pkg/wsman/wsmantesting/responses/amt/wifiportconfiguration/addwifisettings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService"
+    xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/common"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>5</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService/AddWiFiSettingsResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000002965</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/amt-schema/1/AMT_WiFiPortConfigurationService</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:AddWiFiSettings_OUTPUT>
+            <g:ReturnValue>0</g:ReturnValue>
+        </g:AddWiFiSettings_OUTPUT>
+    </a:Body>
+</a:Envelope>


### PR DESCRIPTION
AddWiFiSettings unconditionally set input.CACredential, so adding a new IEEE 802.1x wireless profile without a CA certificate (an optional field) sent AMT firmware an invalid reference with a blank InstanceID selector. AMT rejects it, so every "add" of an 802.1x profile without a CA cert failed. UpdateWiFiSettings already guarded this correctly with `if caCredential != ""`; AddWiFiSettings now matches.

Add regression tests covering both the omitted and included CACredential cases, add the missing addwifisettings.xml response fixture, and drop the stale commented-out AddWiFiSettings test block that referenced types no longer in the codebase.

Refactor: dedupe AddWiFiSettings/UpdateWiFiSettings XML building logic

## Test

Tested e2e functionally on actual device, adding wifi settings without the CACredential object in the wsman call is accepted by AMT FW

## Additional Info

Have checked on wsman-messages for equivalent issue, the same issue is not applicable to wsman-messages.