### PR TITLE
feat(amt): add AddUserAclEntryEx and ACL response types

### DIFF
--- a/pkg/common/decoder.go
+++ b/pkg/common/decoder.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // ReadShort reads a short value from a string at position p.
@@ -53,18 +54,18 @@ func IntToStrX(v int) string {
 }
 
 // MakeToArray attempts to convert an interface to a slice of interfaces.
-func MakeToArray(v interface{}) []interface{} {
-	return []interface{}{v}
+func MakeToArray(v any) []any {
+	return []any{v}
 }
 
 // Rstr2hex converts a raw string to a hex string.
 func Rstr2hex(input string) string {
-	result := ""
+	var result strings.Builder
 	for i := 0; i < len(input); i++ {
-		result += fmt.Sprintf("%02X", input[i])
+		result.WriteString(fmt.Sprintf("%02X", input[i]))
 	}
 
-	return result
+	return result.String()
 }
 
 // Hex2rstr converts a hex string to a raw string.
@@ -84,9 +85,9 @@ func Char2hex(i int) string {
 
 // ComputeDigesthash computes the MD5 digest hash for a set of values.
 func ComputeDigesthash(username, password, realm, method, path, qop, nonce, nc, cnonce string) string {
-	ha1 := md5.Sum([]byte(fmt.Sprintf("%s:%s:%s", username, realm, password)))
-	ha2 := md5.Sum([]byte(fmt.Sprintf("%s:%s", method, path)))
-	final := md5.Sum([]byte(fmt.Sprintf("%x:%s:%s:%s:%s:%x", ha1, nonce, nc, cnonce, qop, ha2)))
+	ha1 := md5.Sum(fmt.Appendf(nil, "%s:%s:%s", username, realm, password))
+	ha2 := md5.Sum(fmt.Appendf(nil, "%s:%s", method, path))
+	final := md5.Sum(fmt.Appendf(nil, "%x:%s:%s:%s:%s:%x", ha1, nonce, nc, cnonce, qop, ha2))
 
 	return fmt.Sprintf("%x", final)
 }
@@ -104,7 +105,8 @@ func RandomValueHex(i int) string {
 // GetSidString converts a byte array of SID into string.
 // Note: This function assumes sid is provided as a string for simplicity but should be []byte in a real Go implementation.
 func GetSidString(sid string) string {
-	value := fmt.Sprintf("S-%d-%d", sid[0], sid[7])
+	var value strings.Builder
+	value.WriteString(fmt.Sprintf("S-%d-%d", sid[0], sid[7]))
 
 	for i := 2; i < len(sid)/4; i++ {
 		substr := sid[i*4 : (i+1)*4]
@@ -114,8 +116,8 @@ func GetSidString(sid string) string {
 			return ""
 		}
 
-		value += fmt.Sprintf("-%d", intValue)
+		value.WriteString(fmt.Sprintf("-%d", intValue))
 	}
 
-	return value
+	return value.String()
 }

--- a/pkg/wsman/amt/authorization/service.go
+++ b/pkg/wsman/amt/authorization/service.go
@@ -262,3 +262,26 @@ func (as Service) SetAdminAclEntryEx(username, digestPassword string) (response 
 
 	return response, err
 }
+
+func (as Service) AddUserAclEntryEx(digestUsername, digestPassword string, accessPermission AccessPermission, realms []RealmValues) (response Response, err error) {
+	header := as.Base.WSManMessageCreator.CreateHeader(methods.GenerateAction(AMTAuthorizationService, AddUserACLEntryEx), AMTAuthorizationService, nil, "", "")
+	body := as.Base.WSManMessageCreator.CreateBody(methods.GenerateInputMethod(AddUserACLEntryEx), AMTAuthorizationService, &AddUserAclEntryEx_INPUT{DigestUsername: digestUsername, DigestPassword: digestPassword, AccessPermission: accessPermission, Realms: realms})
+	response = Response{
+		Message: &client.Message{
+			XMLInput: as.Base.WSManMessageCreator.CreateXML(header, body),
+		},
+	}
+
+	err = as.Base.Execute(response.Message)
+	if err != nil {
+		return response, err
+	}
+
+	// put the xml response into the go struct
+	err = xml.Unmarshal([]byte(response.XMLOutput), &response)
+	if err != nil {
+		return response, err
+	}
+
+	return response, err
+}

--- a/pkg/wsman/amt/authorization/service_test.go
+++ b/pkg/wsman/amt/authorization/service_test.go
@@ -22,7 +22,7 @@ func TestJson(t *testing.T) {
 			GetResponse: AuthorizationOccurrence{},
 		},
 	}
-	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"GetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"AllowHttpQopAuthOnly\":0,\"CreationClassName\":\"\",\"ElementName\":\"\",\"EnabledState\":0,\"Name\":\"\",\"RequestedState\":0,\"SystemCreationClassName\":\"\",\"SystemName\":\"\"},\"EnumerateResponse\":{\"EnumerationContext\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"AuthorizationOccurrenceItems\":null},\"SetAdminResponse\":{\"ReturnValue\":0}}"
+	expectedResult := "{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"GetResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"AllowHttpQopAuthOnly\":0,\"CreationClassName\":\"\",\"ElementName\":\"\",\"EnabledState\":0,\"Name\":\"\",\"RequestedState\":0,\"SystemCreationClassName\":\"\",\"SystemName\":\"\"},\"EnumerateResponse\":{\"EnumerationContext\":\"\"},\"PullResponse\":{\"XMLName\":{\"Space\":\"\",\"Local\":\"\"},\"AuthorizationOccurrenceItems\":null},\"SetAdminResponse\":{\"ReturnValue\":0},\"AddUserResponse\":{\"ReturnValue\":0,\"Handle\":0},\"RemoveUserResponse\":{\"ReturnValue\":0},\"GetUserResponse\":{\"DigestUsername\":\"\",\"KerberosUserSid\":\"\",\"AccessPermission\":0,\"Realms\":null,\"ReturnValue\":0},\"GetACLEnabledStateResponse\":{\"Enabled\":false,\"ReturnValue\":0},\"GetAdminResponse\":{\"Username\":\"\",\"ReturnValue\":0},\"GetAdminStatusResponse\":{\"IsDefault\":false,\"ReturnValue\":0},\"GetAdminNetStatusResponse\":{\"IsDefault\":false,\"ReturnValue\":0},\"SetACLEnabledStateResponse\":{\"ReturnValue\":0},\"EnumerateUserResponse\":{\"TotalCount\":0,\"HandlesCount\":0,\"Handles\":null,\"ReturnValue\":0}}"
 	result := response.JSON()
 	assert.Equal(t, expectedResult, result)
 }
@@ -33,9 +33,25 @@ func TestYaml(t *testing.T) {
 			GetResponse: AuthorizationOccurrence{},
 		},
 	}
-	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\ngetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    allowhttpqopauthonly: 0\n    creationclassname: \"\"\n    elementname: \"\"\n    enabledstate: 0\n    name: \"\"\n    requestedstate: 0\n    systemcreationclassname: \"\"\n    systemname: \"\"\nenumerateresponse:\n    enumerationcontext: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    authorizationoccurrenceitems: []\nsetadminresponse:\n    returnvalue: 0\n"
+	expectedResult := "xmlname:\n    space: \"\"\n    local: \"\"\ngetresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    allowhttpqopauthonly: 0\n    creationclassname: \"\"\n    elementname: \"\"\n    enabledstate: 0\n    name: \"\"\n    requestedstate: 0\n    systemcreationclassname: \"\"\n    systemname: \"\"\nenumerateresponse:\n    enumerationcontext: \"\"\npullresponse:\n    xmlname:\n        space: \"\"\n        local: \"\"\n    authorizationoccurrenceitems: []\nsetadminresponse:\n    returnvalue: 0\nadduserresponse:\n    returnvalue: 0\n    handle: 0\nremoveuserresponse:\n    returnvalue: 0\ngetuserresponse:\n    digestusername: \"\"\n    kerberosusersid: \"\"\n    accesspermission: 0\n    realms: []\n    returnvalue: 0\ngetaclenabledstateresponse:\n    enabled: false\n    returnvalue: 0\ngetadminresponse:\n    username: \"\"\n    returnvalue: 0\ngetadminstatusresponse:\n    isdefault: false\n    returnvalue: 0\ngetadminnetstatusresponse:\n    isdefault: false\n    returnvalue: 0\nsetaclenabledstateresponse:\n    returnvalue: 0\nenumerateuserresponse:\n    totalcount: 0\n    handlescount: 0\n    handles: []\n    returnvalue: 0\n"
 	result := response.YAML()
 	assert.Equal(t, expectedResult, result)
+}
+
+func TestUpdateUserAclEntryExInputMarshalsWSDLFieldOrder(t *testing.T) {
+	request := UpdateUserAclEntryEx_INPUT{
+		H:                "http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService",
+		Handle:           1,
+		DigestUsername:   "test",
+		DigestPassword:   "P@ssw0rd",
+		AccessPermission: AccessPermissionLocalAndNetworkAccess,
+		Realms:           []RealmValues{RealmValuesPTAdministrationRealm},
+	}
+
+	result, err := xml.Marshal(request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, `<h:UpdateUserAclEntryEx_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:Handle>1</h:Handle><h:DigestUsername>test</h:DigestUsername><h:DigestPassword>P@ssw0rd</h:DigestPassword><h:AccessPermission>2</h:AccessPermission><h:Realms>3</h:Realms></h:UpdateUserAclEntryEx_INPUT>`, string(result))
 }
 
 func TestPositiveAMT_AuthorizationService(t *testing.T) {
@@ -130,68 +146,181 @@ func TestPositiveAMT_AuthorizationService(t *testing.T) {
 					},
 				},
 			},
-			// // AUTHORIZATION SERVICE
-
-			// // ADD USER ACL ENTRY EX
-			// // Verify with Matt - Typescript is referring to wrong realm values
-			// // {"should return a valid amt_AuthorizationService ADD_USER_ACL_ENTRY_EX wsman message using digest", AMT_AuthorizationService, ADD_USER_ACL_ENTRY_EX, logrus.Sprintf(`<h:AddUserAclEntryEx_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:DigestUsername>%s</h:DigestUsername><h:DigestPassword>%s</h:DigestPassword><h:AccessPermission>%d</h:AccessPermission><h:Realms>%d</h:Realms></h:AddUserAclEntryEx_INPUT>`, "test", "P@ssw0rd", 2, 3), func() string {
-			// // 	return elementUnderTest.AddUserAclEntryEx(authorization.AccessPermissionLocalAndNetworkAccess, []authorization.RealmValues{authorization.RedirectionRealm}, "test", "P@ssw0rd", "")
-			// // }},
-			// // {"should return a valid amt_AuthorizationService ADD_USER_ACL_ENTRY_EX wsman message using kerberos", AMT_AuthorizationService, ADD_USER_ACL_ENTRY_EX, logrus.Sprintf(`<h:AddUserAclEntryEx_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:KerberosUserSid>%d</h:KerberosUserSid><h:AccessPermission>%d</h:AccessPermission><h:Realms>%d3</h:Realms></h:AddUserAclEntryEx_INPUT>`, 64, 2, 3), func() string {
-			// // 	return elementUnderTest.AddUserAclEntryEx(authorization.AccessPermissionLocalAndNetworkAccess, []authorization.RealmValues{authorization.RedirectionRealm}, "", "", "64")
-			// // }},
-			// // // Check how to verify for exceptions
-			// // // {"should throw an error if the digestUsername is longer than 16 when calling AddUserAclEntryEx", "", "", "", func() string {
-			// // // 	return elementUnderTest.AddUserAclEntryEx(2, []models.RealmValues{models.RedirectionRealm}, "thisusernameistoolong", "test", "")
-			// // // }},
-			// // ENUMERATE USER ACL ENTRIES
-			// {"should return a valid amt_AuthorizationService EnumerateUserAclEntries wsman message when startIndex is undefined", AMT_AuthorizationService, `http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/EnumerateUserAclEntries`, logrus.Sprintf(`<h:EnumerateUserAclEntries_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:StartIndex>%d</h:StartIndex></h:EnumerateUserAclEntries_INPUT>`, 1), func() string {
-			// 	var index int
-			// 	return elementUnderTest.EnumerateUserAclEntries(index)
-			// }},
-			// {"should return a valid amt_AuthorizationService EnumerateUserAclEntries wsman message when startIndex is not 1", AMT_AuthorizationService, `http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/EnumerateUserAclEntries`, logrus.Sprintf(`<h:EnumerateUserAclEntries_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:StartIndex>%d</h:StartIndex></h:EnumerateUserAclEntries_INPUT>`, 50), func() string {
-			// 	return elementUnderTest.EnumerateUserAclEntries(50)
-			// }},
-			// // GET USER ACL ENTRY EX
-			// {"should return a valid amt_AuthorizationService GetUserAclEntryEx wsman message", AMT_AuthorizationService, `http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetUserAclEntryEx`, `<h:GetUserAclEntryEx_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:Handle>1</h:Handle></h:GetUserAclEntryEx_INPUT>`, func() string {
-			// 	return elementUnderTest.GetUserAclEntryEx(1)
-			// }},
-			// // UPDATE USER ACL ENTRY EX
-			// // {"should return a valid amt_AuthorizationService UpdateUserAclEntryEx wsman message using digest", AMT_AuthorizationService, `http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/UpdateUserAclEntryEx`, `<h:GetUserAclEntryEx_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:Handle>1</h:Handle></h:GetUserAclEntryEx_INPUT>`, func() string {
-			// // 	return elementUnderTest.UpdateUserAclEntryEx(1, 2, []authorization.RealmValues{authorization.RedirectionRealm}, "test", "test123!", "")
-			// // }},
-			// // {"should return a valid amt_AuthorizationService UpdateUserAclEntryEx wsman message using kerberos", AMT_AuthorizationService, `http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/UpdateUserAclEntryEx`, `<h:UpdateUserAclEntryEx_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:Handle>1</h:Handle><h:KerberosUserSid>64</h:KerberosUserSid><h:AccessPermission>2</h:AccessPermission><h:Realms>3</h:Realms></h:UpdateUserAclEntryEx_INPUT>`, func() string {
-			// // 	return elementUnderTest.UpdateUserAclEntryEx(1, 2, []authorization.RealmValues{authorization.RedirectionRealm}, "", "", "64")
-			// // }},
-			// // // should throw an error if digest or kerberos credentials are not provided to UpdateUserAclEntryEx
-			// // // should throw an error if the digestUsername is longer than 16 when calling UpdateUserAclEntryEx
-
-			// // REMOVE USER ACL ENTRY
-			// {"should return a valid amt_AuthorizationService RemoveUserAclEntry wsman message", AMT_AuthorizationService, `http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/RemoveUserAclEntry`, `<h:RemoveUserAclEntry_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:Handle>1</h:Handle></h:RemoveUserAclEntry_INPUT>`, func() string {
-			// 	return elementUnderTest.RemoveUserAclEntry(1)
-			// }},
-
-			// // GET ADMIN ACL ENTRY
-			// {"should return a valid amt_AuthorizationService GetAdminAclEntry wsman message", AMT_AuthorizationService, `http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetAdminAclEntry`, `<h:GetAdminAclEntry_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"></h:GetAdminAclEntry_INPUT>`, func() string {
-			// 	return elementUnderTest.GetAdminAclEntry()
-			// }},
-
-			// // GET ADMIN ACL ENTRY STATUS
-			// {"should return a valid amt_AuthorizationService GetAdminAclEntry wsman message", AMT_AuthorizationService, `http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetAdminAclEntryStatus`, `<h:GetAdminAclEntryStatus_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"></h:GetAdminAclEntryStatus_INPUT>`, func() string {
-			// 	return elementUnderTest.GetAdminAclEntryStatus()
-			// }},
-
-			// // GET ADMIN NET ACL ENTRY STATUS
-			// {"should return a valid amt_AuthorizationService GetAdminNetAclEntryStatus wsman message", AMT_AuthorizationService, `http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetAdminNetAclEntryStatus`, `<h:GetAdminNetAclEntryStatus_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"></h:GetAdminNetAclEntryStatus_INPUT>`, func() string {
-			// 	return elementUnderTest.GetAdminNetAclEntryStatus()
-			// }},
-
-			// // GET ACL ENABLED STATE
-			// {"should return a valid amt_AuthorizationService GetAclEnabledState wsman message", AMT_AuthorizationService, `http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetAclEnabledState`, `<h:GetAclEnabledState_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:Handle>1</h:Handle></h:GetAclEnabledState_INPUT>`, func() string {
-			// 	return elementUnderTest.GetAclEnabledState(1)
-			// }},
-
-			// SET ADMIN ACL ENTRY
+			// AUTHORIZATION SERVICE
+			{
+				"should create a valid amt_AuthorizationService AddUserAclEntryEx wsman message using digest",
+				AMTAuthorizationService,
+				`http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/AddUserAclEntryEx`,
+				`<h:AddUserAclEntryEx_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:DigestUsername>test</h:DigestUsername><h:DigestPassword>P@ssw0rd</h:DigestPassword><h:AccessPermission>2</h:AccessPermission><h:Realms>3</h:Realms></h:AddUserAclEntryEx_INPUT>`,
+				func() (Response, error) {
+					client.CurrentMessage = "AddUserAclEntryEx"
+					return elementUnderTest.AddUserAclEntryEx("test", "P@ssw0rd", AccessPermissionLocalAndNetworkAccess, []RealmValues{RealmValuesPTAdministrationRealm})
+				},
+				Body{
+					XMLName: xml.Name{Space: "http://www.w3.org/2003/05/soap-envelope", Local: "Body"},
+					AddUserResponse: AddUserAclEntryEx_OUTPUT{
+						ReturnValue: 0,
+						Handle:      1,
+					},
+				},
+			},
+			{
+				"should return a valid amt_AuthorizationService EnumerateUserAclEntries wsman message when startIndex is 0 (defaults to 1)",
+				AMTAuthorizationService,
+				`http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/EnumerateUserAclEntries`,
+				`<h:EnumerateUserAclEntries_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:StartIndex>1</h:StartIndex></h:EnumerateUserAclEntries_INPUT>`,
+				func() (Response, error) {
+					client.CurrentMessage = "EnumerateUserAclEntries"
+					return elementUnderTest.EnumerateUserACLEntries(0)
+				},
+				Body{
+					XMLName: xml.Name{Space: "http://www.w3.org/2003/05/soap-envelope", Local: "Body"},
+					EnumerateUserResponse: EnumerateUserAclEntries_OUTPUT{
+						TotalCount:   2,
+						HandlesCount: 2,
+						Handles:      []int{1, 2},
+						ReturnValue:  0,
+					},
+				},
+			},
+			{
+				"should return a valid amt_AuthorizationService EnumerateUserAclEntries wsman message when startIndex is not 1",
+				AMTAuthorizationService,
+				`http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/EnumerateUserAclEntries`,
+				`<h:EnumerateUserAclEntries_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:StartIndex>50</h:StartIndex></h:EnumerateUserAclEntries_INPUT>`,
+				func() (Response, error) {
+					client.CurrentMessage = "EnumerateUserAclEntries"
+					return elementUnderTest.EnumerateUserACLEntries(50)
+				},
+				Body{
+					XMLName: xml.Name{Space: "http://www.w3.org/2003/05/soap-envelope", Local: "Body"},
+					EnumerateUserResponse: EnumerateUserAclEntries_OUTPUT{
+						TotalCount:   2,
+						HandlesCount: 2,
+						Handles:      []int{1, 2},
+						ReturnValue:  0,
+					},
+				},
+			},
+			{
+				"should return a valid amt_AuthorizationService GetUserAclEntryEx wsman message",
+				AMTAuthorizationService,
+				`http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetUserAclEntryEx`,
+				`<h:GetUserAclEntryEx_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:Handle>1</h:Handle></h:GetUserAclEntryEx_INPUT>`,
+				func() (Response, error) {
+					client.CurrentMessage = "GetUserAclEntryEx"
+					return elementUnderTest.GetUserACLEntryEx(1)
+				},
+				Body{
+					XMLName: xml.Name{Space: "http://www.w3.org/2003/05/soap-envelope", Local: "Body"},
+					GetUserResponse: GetUserAclEntryEx_OUTPUT{
+						DigestUsername:   "$$uns",
+						AccessPermission: 0,
+						Realms:           []RealmValues{16},
+						ReturnValue:      0,
+					},
+				},
+			},
+			{
+				"should return a valid amt_AuthorizationService RemoveUserAclEntry wsman message",
+				AMTAuthorizationService,
+				`http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/RemoveUserAclEntry`,
+				`<h:RemoveUserAclEntry_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:Handle>1</h:Handle></h:RemoveUserAclEntry_INPUT>`,
+				func() (Response, error) {
+					client.CurrentMessage = "RemoveUserAclEntry"
+					return elementUnderTest.RemoveUserACLEntry(1)
+				},
+				Body{
+					XMLName: xml.Name{Space: "http://www.w3.org/2003/05/soap-envelope", Local: "Body"},
+					RemoveUserResponse: RemoveUserAclEntry_OUTPUT{
+						ReturnValue: 0,
+					},
+				},
+			},
+			{
+				"should return a valid amt_AuthorizationService GetAdminAclEntry wsman message",
+				AMTAuthorizationService,
+				`http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetAdminAclEntry`,
+				`<h:GetAdminAclEntry_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"></h:GetAdminAclEntry_INPUT>`,
+				func() (Response, error) {
+					client.CurrentMessage = "GetAdminAclEntry"
+					return elementUnderTest.GetAdminACLEntry()
+				},
+				Body{
+					XMLName: xml.Name{Space: "http://www.w3.org/2003/05/soap-envelope", Local: "Body"},
+					GetAdminResponse: GetAdminAclEntry_OUTPUT{
+						Username:    "admin",
+						ReturnValue: 0,
+					},
+				},
+			},
+			{
+				"should return a valid amt_AuthorizationService GetAdminAclEntryStatus wsman message",
+				AMTAuthorizationService,
+				`http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetAdminAclEntryStatus`,
+				`<h:GetAdminAclEntryStatus_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"></h:GetAdminAclEntryStatus_INPUT>`,
+				func() (Response, error) {
+					client.CurrentMessage = "GetAdminAclEntryStatus"
+					return elementUnderTest.GetAdminACLEntryStatus()
+				},
+				Body{
+					XMLName: xml.Name{Space: "http://www.w3.org/2003/05/soap-envelope", Local: "Body"},
+					GetAdminStatusResponse: GetAdminAclEntryStatus_OUTPUT{
+						IsDefault:   false,
+						ReturnValue: 0,
+					},
+				},
+			},
+			{
+				"should return a valid amt_AuthorizationService GetAdminNetAclEntryStatus wsman message",
+				AMTAuthorizationService,
+				`http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetAdminNetAclEntryStatus`,
+				`<h:GetAdminNetAclEntryStatus_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"></h:GetAdminNetAclEntryStatus_INPUT>`,
+				func() (Response, error) {
+					client.CurrentMessage = "GetAdminNetAclEntryStatus"
+					return elementUnderTest.GetAdminNetACLEntryStatus()
+				},
+				Body{
+					XMLName: xml.Name{Space: "http://www.w3.org/2003/05/soap-envelope", Local: "Body"},
+					GetAdminNetStatusResponse: GetAdminNetAclEntryStatus_OUTPUT{
+						IsDefault:   false,
+						ReturnValue: 0,
+					},
+				},
+			},
+			{
+				"should return a valid amt_AuthorizationService GetAclEnabledState wsman message",
+				AMTAuthorizationService,
+				`http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetAclEnabledState`,
+				`<h:GetAclEnabledState_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:Handle>1</h:Handle></h:GetAclEnabledState_INPUT>`,
+				func() (Response, error) {
+					client.CurrentMessage = "GetAclEnabledState"
+					return elementUnderTest.GetACLEnabledState(1)
+				},
+				Body{
+					XMLName: xml.Name{Space: "http://www.w3.org/2003/05/soap-envelope", Local: "Body"},
+					GetACLEnabledStateResponse: GetAclEnabledState_OUTPUT{
+						Enabled:     true,
+						ReturnValue: 0,
+					},
+				},
+			},
+			{
+				"should return a valid amt_AuthorizationService SetAclEnabledState wsman message",
+				AMTAuthorizationService,
+				`http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/SetAclEnabledState`,
+				`<h:SetAclEnabledState_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"><h:Handle>1</h:Handle><h:Enabled>true</h:Enabled></h:SetAclEnabledState_INPUT>`,
+				func() (Response, error) {
+					client.CurrentMessage = "SetAclEnabledState"
+					return elementUnderTest.SetACLEnabledState(1, true)
+				},
+				Body{
+					XMLName: xml.Name{Space: "http://www.w3.org/2003/05/soap-envelope", Local: "Body"},
+					SetACLEnabledStateResponse: SetAclEnabledState_OUTPUT{
+						ReturnValue: 0,
+					},
+				},
+			},
 			{
 				"should return a valid amt_AuthorizationService SetAdminAclEntryEx wsman message",
 				AMTAuthorizationService,

--- a/pkg/wsman/amt/authorization/types.go
+++ b/pkg/wsman/amt/authorization/types.go
@@ -23,14 +23,65 @@ type (
 		Body    Body           `xml:"Body"`
 	}
 	Body struct {
-		XMLName           xml.Name `xml:"Body"`
-		GetResponse       AuthorizationOccurrence
-		EnumerateResponse common.EnumerateResponse
-		PullResponse      PullResponse
-		SetAdminResponse  SetAdminAclEntryEx_OUTPUT
+		XMLName                    xml.Name `xml:"Body"`
+		GetResponse                AuthorizationOccurrence
+		EnumerateResponse          common.EnumerateResponse
+		PullResponse               PullResponse
+		SetAdminResponse           SetAdminAclEntryEx_OUTPUT        `xml:"SetAdminAclEntryEx_OUTPUT"`
+		AddUserResponse            AddUserAclEntryEx_OUTPUT         `xml:"AddUserAclEntryEx_OUTPUT"`
+		RemoveUserResponse         RemoveUserAclEntry_OUTPUT        `xml:"RemoveUserAclEntry_OUTPUT"`
+		GetUserResponse            GetUserAclEntryEx_OUTPUT         `xml:"GetUserAclEntryEx_OUTPUT"`
+		GetACLEnabledStateResponse GetAclEnabledState_OUTPUT        `xml:"GetAclEnabledState_OUTPUT"`
+		GetAdminResponse           GetAdminAclEntry_OUTPUT          `xml:"GetAdminAclEntry_OUTPUT"`
+		GetAdminStatusResponse     GetAdminAclEntryStatus_OUTPUT    `xml:"GetAdminAclEntryStatus_OUTPUT"`
+		GetAdminNetStatusResponse  GetAdminNetAclEntryStatus_OUTPUT `xml:"GetAdminNetAclEntryStatus_OUTPUT"`
+		SetACLEnabledStateResponse SetAclEnabledState_OUTPUT        `xml:"SetAclEnabledState_OUTPUT"`
+		EnumerateUserResponse      EnumerateUserAclEntries_OUTPUT   `xml:"EnumerateUserAclEntries_OUTPUT"`
 	}
 	SetAdminAclEntryEx_OUTPUT struct {
 		ReturnValue ReturnValue `xml:"ReturnValue"`
+	}
+	AddUserAclEntry_OUTPUT struct {
+		ReturnValue ReturnValue `xml:"ReturnValue"`
+	}
+	AddUserAclEntryEx_OUTPUT struct {
+		ReturnValue ReturnValue `xml:"ReturnValue"`
+		Handle      int         `xml:"Handle"`
+	}
+	RemoveUserAclEntry_OUTPUT struct {
+		ReturnValue ReturnValue `xml:"ReturnValue"`
+	}
+	GetAclEnabledState_OUTPUT struct {
+		Enabled     bool        `xml:"Enabled"`
+		ReturnValue ReturnValue `xml:"ReturnValue"`
+	}
+	GetAdminAclEntry_OUTPUT struct {
+		Username    string      `xml:"Username"`
+		ReturnValue ReturnValue `xml:"ReturnValue"`
+	}
+	GetAdminAclEntryStatus_OUTPUT struct {
+		IsDefault   bool        `xml:"IsDefault"`
+		ReturnValue ReturnValue `xml:"ReturnValue"`
+	}
+	GetAdminNetAclEntryStatus_OUTPUT struct {
+		IsDefault   bool        `xml:"IsDefault"`
+		ReturnValue ReturnValue `xml:"ReturnValue"`
+	}
+	SetAclEnabledState_OUTPUT struct {
+		ReturnValue ReturnValue `xml:"ReturnValue"`
+	}
+	GetUserAclEntryEx_OUTPUT struct {
+		DigestUsername   string           `xml:"DigestUsername,omitempty"`
+		KerberosUserSid  string           `xml:"KerberosUserSid,omitempty"`
+		AccessPermission AccessPermission `xml:"AccessPermission"`
+		Realms           []RealmValues    `xml:"Realms"`
+		ReturnValue      ReturnValue      `xml:"ReturnValue"`
+	}
+	EnumerateUserAclEntries_OUTPUT struct {
+		TotalCount   int         `xml:"TotalCount"`
+		HandlesCount int         `xml:"HandlesCount"`
+		Handles      []int       `xml:"Handles"`
+		ReturnValue  ReturnValue `xml:"ReturnValue"`
 	}
 	AuthorizationOccurrence struct {
 		XMLName                 xml.Name       `xml:"AMT_AuthorizationService"`
@@ -67,6 +118,11 @@ type AccessPermission int
 //
 // Values={InvalidRealm, ReservedRealm0, RedirectionRealm, PTAdministrationRealm, HardwareAssetRealm, RemoteControlRealm, StorageRealm, EventManagerRealm, StorageAdminRealm, AgentPresenceLocalRealm, AgentPresenceRemoteRealm, CircuitBreakerRealm, NetworkTimeRealm, GeneralInfoRealm, FirmwareUpdateRealm, EITRealm, LocalUN, EndpointAccessControlRealm, EndpointAccessControlAdminRealm, EventLogReaderRealm, AuditLogRealm, ACLRealm, ReservedRealm1, ReservedRealm2, LocalSystemRealm, Reserved}.
 type RealmValues int
+
+// ValueMap={0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, ..}
+//
+// Values={InvalidRealm, ReservedRealm0, RedirectionRealm, PTAdministrationRealm, HardwareAssetRealm, RemoteControlRealm, StorageRealm, EventManagerRealm, StorageAdminRealm, AgentPresenceLocalRealm, AgentPresenceRemoteRealm, CircuitBreakerRealm, NetworkTimeRealm, GeneralInfoRealm, FirmwareUpdateRealm, EITRealm, LocalUN, EndpointAccessControlRealm, EndpointAccessControlAdminRealm, EventLogReaderRealm, AuditLogRealm, ACLRealm, ReservedRealm1, ReservedRealm2, LocalSystemRealm, Reserved}.
+type Realms int
 
 // INPUTS
 // Request Types.
@@ -106,24 +162,23 @@ type (
 		Username       string   `xml:"h:Username"`       // Username for access control. Contains 7-bit ASCII characters. String length is limited to 16 characters. Username cannot be an empty string.
 		DigestPassword string   `xml:"h:DigestPassword"` // An MD5 Hash of these parameters concatenated together (Username + ":" + DigestRealm + ":" + Password). The DigestRealm is a field in AMT_GeneralSettings
 	}
-	AddUserAclEntry struct {
+	AddUserAclEntryEx_INPUT struct {
 		XMLName          xml.Name         `xml:"h:AddUserAclEntryEx_INPUT"`
 		H                string           `xml:"xmlns:h,attr"`
-		Handle           int              `xml:"h:Handle,omitempty"`              // Contains a creation handle.
-		DigestUsername   string           `xml:"h:DigestUsername"`                // Username for access control. Contains 7-bit ASCII characters. String length is limited to 16 characters. Username cannot be an empty string.
-		DigestPassword   string           `xml:"h:DigestPassword"`                // An MD5 Hash of these parameters concatenated together (Username + ":" + DigestRealm + ":" + Password). The DigestRealm is a field in AMT_GeneralSettings
-		AccessPermission AccessPermission `xml:"h:AccessPermission"`              // Indicates whether the User is allowed to access Intel® AMT from the Network or Local Interfaces. Note: this definition is restricted by the Default Interface Access Permissions of each Realm.
-		Realms           []RealmValues    `xml:"h:Realms>h:RealmValue,omitempty"` // Array of interface names the ACL entry is allowed to access.
-		KerberosUserSid  string           `xml:"h:KerberosUserSid"`               // Descriptor for user (SID) which is authenticated using the Kerberos Authentication. Byte array, specifying the Security Identifier (SID) according to the Kerberos specification. Current requirements imply that SID should be not smaller than 1 byte length and no longer than 28 bytes. SID length should also be a multiplicand of 4.
+		DigestUsername   string           `xml:"h:DigestUsername"`            // Username for access control. Contains 7-bit ASCII characters. String length is limited to 16 characters. Username cannot be an empty string.
+		DigestPassword   string           `xml:"h:DigestPassword"`            // An MD5 Hash of these parameters concatenated together (Username + ":" + DigestRealm + ":" + Password). The DigestRealm is a field in AMT_GeneralSettings
+		KerberosUserSid  string           `xml:"h:KerberosUserSid,omitempty"` // Descriptor for user (SID) which is authenticated using the Kerberos Authentication. Byte array, specifying the Security Identifier (SID) according to the Kerberos specification. Current requirements imply that SID should be not smaller than 1 byte length and no longer than 28 bytes. SID length should also be a multiplicand of 4.
+		AccessPermission AccessPermission `xml:"h:AccessPermission"`          // Indicates whether the User is allowed to access Intel® AMT from the Network or Local Interfaces. Note: this definition is restricted by the Default Interface Access Permissions of each Realm.
+		Realms           []RealmValues    `xml:"h:Realms,omitempty"`          // Array of interface names the ACL entry is allowed to access.
 	}
-	UpdateUserAclEntry struct {
-		XMLName          xml.Name         `xml:"h:UpdateUserAclEntry_INPUT"`
+	UpdateUserAclEntryEx_INPUT struct {
+		XMLName          xml.Name         `xml:"h:UpdateUserAclEntryEx_INPUT"`
 		H                string           `xml:"xmlns:h,attr"`
-		Handle           int              `xml:"h:Handle,omitempty"`              // Contains a creation handle.
-		DigestUsername   string           `xml:"h:DigestUsername"`                // Username for access control. Contains 7-bit ASCII characters. String length is limited to 16 characters. Username cannot be an empty string.
-		DigestPassword   string           `xml:"h:DigestPassword"`                // An MD5 Hash of these parameters concatenated together (Username + ":" + DigestRealm + ":" + Password). The DigestRealm is a field in AMT_GeneralSettings
-		AccessPermission AccessPermission `xml:"h:AccessPermission"`              // Indicates whether the User is allowed to access Intel® AMT from the Network or Local Interfaces. Note: this definition is restricted by the Default Interface Access Permissions of each Realm.
-		Realms           []RealmValues    `xml:"h:Realms>h:RealmValue,omitempty"` // Array of interface names the ACL entry is allowed to access.
-		KerberosUserSid  string           `xml:"h:KerberosUserSid"`               // Descriptor for user (SID) which is authenticated using the Kerberos Authentication. Byte array, specifying the Security Identifier (SID) according to the Kerberos specification. Current requirements imply that SID should be not smaller than 1 byte length and no longer than 28 bytes. SID length should also be a multiplicand of 4.
+		Handle           int              `xml:"h:Handle"`                    // Contains a creation handle.
+		DigestUsername   string           `xml:"h:DigestUsername"`            // Username for access control. Contains 7-bit ASCII characters. String length is limited to 16 characters. Username cannot be an empty string.
+		DigestPassword   string           `xml:"h:DigestPassword"`            // An MD5 Hash of these parameters concatenated together (Username + ":" + DigestRealm + ":" + Password). The DigestRealm is a field in AMT_GeneralSettings
+		KerberosUserSid  string           `xml:"h:KerberosUserSid,omitempty"` // Descriptor for user (SID) which is authenticated using the Kerberos Authentication. Byte array, specifying the Security Identifier (SID) according to the Kerberos specification. Current requirements imply that SID should be not smaller than 1 byte length and no longer than 28 bytes. SID length should also be a multiplicand of 4.
+		AccessPermission AccessPermission `xml:"h:AccessPermission"`          // Indicates whether the User is allowed to access Intel® AMT from the Network or Local Interfaces. Note: this definition is restricted by the Default Interface Access Permissions of each Realm.
+		Realms           []RealmValues    `xml:"h:Realms,omitempty"`          // Array of interface names the ACL entry is allowed to access.
 	}
 )

--- a/pkg/wsman/base/wsmanservice.go
+++ b/pkg/wsman/base/wsmanservice.go
@@ -140,7 +140,7 @@ func injectMessage[T any](v *T, msg *client.Message) {
 
 func injectNamespace(request any, resourceURI string) {
 	rv := reflect.ValueOf(request)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 

--- a/pkg/wsman/client/types.go
+++ b/pkg/wsman/client/types.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"time"
 )
 
 // Parameters struct defines the connection settings for wsman client.
@@ -28,4 +29,5 @@ type Parameters struct {
 	AllowInsecureCipherSuites bool
 	IsCIRA                    bool               // Flag to indicate CIRA APF tunnel connection
 	CIRAManager               CIRAChannelManager // Manager for CIRA channel operations
+	Timeout                   time.Duration
 }

--- a/pkg/wsman/client/wsman.go
+++ b/pkg/wsman/client/wsman.go
@@ -70,9 +70,8 @@ type Target struct {
 	InsecureSkipVerify bool
 	PinnedCert         string
 	tlsConfig          *tls.Config
+	Timeout            time.Duration
 }
-
-const timeout = 10 * time.Second
 
 func NewWsman(cp Parameters) *Target {
 	path := WSManPath
@@ -97,9 +96,10 @@ func NewWsman(cp Parameters) *Target {
 		InsecureSkipVerify: cp.SelfSignedAllowed,
 		conn:               cp.Connection,
 		tlsConfig:          cp.TlsConfig,
+		Timeout:            cp.Timeout,
 	}
-
-	res.Timeout = timeout
+	runTimeout := time.Duration(max(10, cp.Timeout)) * time.Second
+	res.Timeout = runTimeout
 
 	if cp.Transport == nil {
 		// Use CIRATransport for CIRA APF tunnel connections

--- a/pkg/wsman/wsmantesting/responses/amt/authorization/adduseraclentryex.xml
+++ b/pkg/wsman/wsmantesting/responses/amt/authorization/adduseraclentryex.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+    xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+    xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+    xmlns:g="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>1</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/AddUserAclEntryExResponse</b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-00000000259C</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:AddUserAclEntryEx_OUTPUT>
+            <g:Handle>1</g:Handle>
+            <g:ReturnValue>0</g:ReturnValue>
+        </g:AddUserAclEntryEx_OUTPUT>
+    </a:Body>
+</a:Envelope>


### PR DESCRIPTION
## Summary

- Add AMT authorization support for `AddUserAclEntryEx`, including response types, XML fixture coverage, and updated service tests.
- Expand AMT authorization response models for ACL/user/admin methods.
- Refactor WiFi port configuration request construction by sharing reference-parameter and IEEE 802.1x credential helpers.
- Avoid emitting empty client/CA credential references for WiFi 802.1x settings.
- Update client timeout handling to use `time.Duration`.
- Apply style and consistency updates across decoder/base/client code.
- Update CI/security workflow pins, Dependabot grouping, and zizmor configuration.

## Testing

- Not run as part of this PR-message draft.
