### PR TITLE
fix: Handle panic in channel-close handling when session is nil

### DIFF
--- a/pkg/apf/processor.go
+++ b/pkg/apf/processor.go
@@ -364,7 +364,7 @@ func ProcessChannelWindowAdjust(data []byte, session *Session) {
 	log.Tracef("%+v", adjustMessage)
 }
 
-func ProcessChannelClose(data []byte, session *Session) APF_CHANNEL_CLOSE_MESSAGE {
+func ProcessChannelClose(data []byte, session *Session) *APF_CHANNEL_CLOSE_MESSAGE {
 	closeMessage := APF_CHANNEL_CLOSE_MESSAGE{}
 	dataBuffer := bytes.NewBuffer(data)
 
@@ -407,7 +407,15 @@ func ProcessChannelClose(data []byte, session *Session) APF_CHANNEL_CLOSE_MESSAG
 		session.Timer.Stop()
 	}
 
-	return ChannelClose(session.SenderChannel)
+	if session == nil {
+		log.Warn("received APF_CHANNEL_CLOSE with nil session; skipping ACK")
+
+		return nil
+	}
+
+	message := ChannelClose(session.SenderChannel)
+
+	return &message
 }
 
 // ProcessGlobalRequest decodes the global request and returns both the decoded info and the reply.

--- a/pkg/apf/processor_test.go
+++ b/pkg/apf/processor_test.go
@@ -72,6 +72,15 @@ func TestProcessChannelClose(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
+func TestProcessChannelCloseNilSession(t *testing.T) {
+	t.Parallel()
+
+	data := []byte{0x01}
+	result := ProcessChannelClose(data, nil)
+
+	assert.Nil(t, result)
+}
+
 func TestProcessChannelCloseFlushesTempdata(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
1. Add a nil-session guard in pkg/apf/processor.go so APF_CHANNEL_CLOSE skips ACK safely instead of dereferencing session.
2. Return no ACK when session is nil, with a warning log.
3. Add regression coverage in pkg/apf/processor_test.go for the nil-session path.